### PR TITLE
Route-specific metrics

### DIFF
--- a/pkg/router/route.go
+++ b/pkg/router/route.go
@@ -25,7 +25,7 @@ func (r *Router[T, U]) RegisterRoute(route RouteConfigBase) {
 
 	// Register the route with httprouter
 	for _, method := range route.Methods {
-		r.router.Handle(string(method), route.Path, r.convertToHTTPRouterHandle(handler)) // Convert HttpMethod to string
+		r.router.Handle(string(method), route.Path, r.convertToHTTPRouterHandle(handler, route.Path)) // Convert HttpMethod to string
 	}
 }
 
@@ -228,7 +228,7 @@ func RegisterGenericRoute[Req any, Resp any, UserID comparable, User any](
 
 	// Register the route with httprouter
 	for _, method := range route.Methods {
-		r.router.Handle(string(method), route.Path, r.convertToHTTPRouterHandle(wrappedHandler)) // Convert HttpMethod to string
+		r.router.Handle(string(method), route.Path, r.convertToHTTPRouterHandle(wrappedHandler, route.Path)) // Convert HttpMethod to string
 	}
 }
 


### PR DESCRIPTION
## Pull Request Overview

This PR introduces support for route-specific context information and metrics via route templates and path parameters, improving the observability of requests by associating metrics with logical routes rather than literal paths. Key changes include:
- Adding route information (template, path params, and a flag) to the SRouterContext in pkg/scontext/context.go.
- Updating router handlers in pkg/router/router.go and pkg/router/route.go to include route templates in the context.
- Enhancing the metrics middleware and its tests in pkg/metrics/* to support route-specific and global metric tagging.
- Updating documentation in docs/metrics.md to reflect these new capabilities.

| File                               | Description                                                         |
| ---------------------------------- | ------------------------------------------------------------------- |
| pkg/scontext/context.go            | Adds route template and path parameters to context along with getters. |
| pkg/router/router.go               | Updates handler conversion to inject route info into the context.   |
| pkg/router/route.go                | Aligns route registration with new route template parameter.        |
| pkg/metrics/metrics_test.go        | Adds tests for route template metrics extraction and global metrics.  |
| pkg/metrics/handler_method.go      | Implements route-specific and global metrics collection using route tags. |
| docs/metrics.md                    | Updates metrics documentation to include route template tagging.      |
</details>

