### PR TITLE
Add stop support for trace ID generator

### DIFF
--- a/pkg/middleware/trace_stop_test.go
+++ b/pkg/middleware/trace_stop_test.go
@@ -1,0 +1,29 @@
+package middleware
+
+import (
+	"testing"
+	"time"
+)
+
+// TestIDGeneratorStopDuringBatchFill ensures Stop terminates the generator when batching.
+func TestIDGeneratorStopDuringBatchFill(t *testing.T) {
+	bufferSize := 50
+	g := NewIDGenerator(bufferSize)
+	// Drain the buffer to force batch refill
+	for i := 0; i < bufferSize; i++ {
+		_ = g.GetIDNonBlocking()
+	}
+
+	time.Sleep(1 * time.Millisecond) // allow background filler to start batching
+	g.Stop()
+	g.Stop() // second call should be safe
+}
+
+// TestIDGeneratorStopDuringNormalFill ensures Stop works during normal generation.
+func TestIDGeneratorStopDuringNormalFill(t *testing.T) {
+	g := NewIDGenerator(1)
+	_ = g.GetIDNonBlocking() // drain so filler runs normally
+	time.Sleep(1 * time.Millisecond)
+	g.Stop()
+	g.Stop()
+}

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -766,6 +766,10 @@ func (r *Router[T, U]) Shutdown(ctx context.Context) error {
 	r.shutdown = true
 	r.shutdownMu.Unlock()
 
+	if r.traceIDGenerator != nil {
+		r.traceIDGenerator.Stop()
+	}
+
 	// Create a channel to signal when all requests are done
 	done := make(chan struct{})
 	go func() {

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -663,6 +663,20 @@ func TestShutdownWithCancel(t *testing.T) {
 	}
 }
 
+// TestShutdownStopsIDGenerator ensures the trace ID generator is stopped on shutdown.
+func TestShutdownStopsIDGenerator(t *testing.T) {
+	r := NewRouter(RouterConfig{Logger: zap.NewNop(), TraceIDBufferSize: 2}, mocks.MockAuthFunction, mocks.MockUserIDFromUser)
+	ctx := context.Background()
+	if err := r.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown failed: %v", err)
+	}
+
+	if r.traceIDGenerator != nil {
+		// Calling Stop again should be safe and not panic
+		r.traceIDGenerator.Stop()
+	}
+}
+
 // --- Tests for Refactored Generic SubRouter Registration ---
 
 // TestFindSubRouterConfig tests the helper function for finding sub-router configs


### PR DESCRIPTION
## Summary
- add `stop` channel and `Stop` method to `middleware.IDGenerator`
- exit background goroutine when stop is signaled
- stop the generator in `Router.Shutdown`
- test that the generator can be stopped during shutdown

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*