### PR TITLE
Fix outdated docs for trace IDs & metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,12 +105,12 @@ func main() {
 	defer logger.Sync()
 
 	// Create a router configuration
-	routerConfig := router.RouterConfig{
-		Logger:            logger, // Required
-		GlobalTimeout:     2 * time.Second,
-		GlobalMaxBodySize: 1 << 20, // 1 MB
-		EnableTraceID:     true,    // Enable trace ID logging (recommended)
-		Middlewares: []common.Middleware{
+        routerConfig := router.RouterConfig{
+                Logger:            logger, // Required
+                GlobalTimeout:     2 * time.Second,
+                GlobalMaxBodySize: 1 << 20, // 1 MB
+                TraceIDBufferSize: 1000,    // Enable trace ID logging
+                Middlewares: []common.Middleware{
 		 // Add other desired global middleware here.
 		 // Logging is handled internally by the router based on RouterConfig settings.
 		},
@@ -1047,7 +1047,7 @@ SRouter features a flexible, interface-based metrics system located in the `pkg/
 
 #### Enabling and Configuring Metrics
 
-To enable metrics, set `EnableMetrics: true` in your `RouterConfig`. You can further customize behavior using the `MetricsConfig` field:
+Metrics collection is enabled by providing a non-nil `MetricsConfig` in your `RouterConfig`:
 
 ```go
 // Example: Configure metrics using MetricsConfig
@@ -1055,7 +1055,6 @@ routerConfig := router.RouterConfig{
     Logger:            logger, // Required
     GlobalTimeout:     2 * time.Second,
     GlobalMaxBodySize: 1 << 20, // 1 MB
-    EnableMetrics:     true,      // Enable metrics collection
     MetricsConfig: &router.MetricsConfig{
         // Provide your implementations of metrics interfaces (MetricsRegistry, MetricsMiddleware)
         // If nil, SRouter might use default implementations if available.
@@ -1155,11 +1154,10 @@ type RouterConfig struct {
  GlobalMaxBodySize  int64                             // Default maximum request body size in bytes
  GlobalRateLimit    *common.RateLimitConfig[any, any] // Default rate limit for all routes (uses common.RateLimitConfig)
  IPConfig           *router.IPConfig                  // Configuration for client IP extraction (uses router.IPConfig)
- EnableMetrics      bool                              // Enable metrics collection
  EnableTraceLogging bool                              // Enable detailed trace logging (default: false, uses Debug level)
- TraceLoggingUseInfo bool                             // Log traces at Info level instead of Debug (default: false)
- TraceIDBufferSize  int                               // Buffer size for trace ID generator (0 disables trace ID generation, >0 enables it)
- MetricsConfig      *router.MetricsConfig             // Metrics configuration (optional, uses router.MetricsConfig)
+TraceLoggingUseInfo bool                             // Log traces at Info level instead of Debug (default: false)
+TraceIDBufferSize  int                               // Buffer size for trace ID generator (0 disables trace ID generation, >0 enables it)
+ MetricsConfig      *router.MetricsConfig             // Metrics configuration (non-nil to enable metrics)
  SubRouters         []SubRouterConfig                 // Sub-routers with their own configurations
  Middlewares        []common.Middleware               // Global middlewares applied to all routes (uses common.Middleware)
  AddUserObjectToCtx bool                              // Add user object to context (used by built-in auth middleware)
@@ -1171,7 +1169,7 @@ type RouterConfig struct {
 ```go
 type MetricsConfig struct {
  // Collector is the metrics collector to use.
- // Must implement metrics.MetricsRegistry. Required if EnableMetrics is true.
+ // Must implement metrics.MetricsRegistry. Required when metrics are enabled.
  Collector any // Must implement metrics.MetricsRegistry
 
  // MiddlewareFactory is the factory for creating metrics middleware.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,12 +1,3 @@
-	// EnableTracing enables distributed tracing support (Note: Actual implementation
-	// might be via specific tracing middleware rather than just this flag).
-	EnableTracing bool // Check if still relevant or handled by middleware
-
-	// EnableTraceID enables automatic trace ID generation and injection into the request context.
-	// If true, the router handles trace ID setup internally. Alternatively, set this to false
-	// and explicitly add middleware.TraceMiddleware() to the Middlewares slice.
-	// See docs/trace-logging.md for details.
-	EnableTraceID bool
 # Configuration Reference
 
 This section details the configuration structs used by SRouter.
@@ -49,12 +40,9 @@ type RouterConfig struct {
 	// See docs/ip-configuration.md. Nil uses default (RemoteAddr, no proxy trust).
 	IPConfig *IPConfig // Defined in router package
 
-	// EnableMetrics globally enables or disables the metrics collection system.
-	EnableMetrics bool
-
-	// EnableTraceLogging enables detailed request/response logging including timing, status, etc.
-	// Often used in conjunction with TraceIDBufferSize > 0.
-	EnableTraceLogging bool
+        // EnableTraceLogging enables detailed request/response logging including timing, status, etc.
+        // Often used in conjunction with TraceIDBufferSize > 0.
+        EnableTraceLogging bool
 
 	// TraceLoggingUseInfo controls the log level for trace logging.
 	// If true, logs at Info level; otherwise, logs at Debug level.
@@ -65,9 +53,9 @@ type RouterConfig struct {
 	// Setting to 0 disables automatic trace ID generation. See docs/trace-logging.md.
 	TraceIDBufferSize int
 
-	// MetricsConfig holds detailed configuration for the v2 metrics system when EnableMetrics is true.
-	// See MetricsConfig section below and docs/metrics.md.
-	MetricsConfig *MetricsConfig
+        // MetricsConfig holds detailed configuration for the v2 metrics system.
+        // Metrics are enabled when this field is non-nil. See docs/metrics.md.
+        MetricsConfig *MetricsConfig
 
 	// SubRouters is a slice of SubRouterConfig structs defining sub-routers. Required.
 	SubRouters []SubRouterConfig
@@ -94,9 +82,9 @@ package router
 import "github.com/Suhaibinator/SRouter/pkg/metrics" // Assuming interfaces are here
 
 type MetricsConfig struct {
-	// Collector provides the implementation for creating and managing metric instruments.
-	// Must implement metrics.MetricsRegistry. Required if EnableMetrics is true.
-	Collector any // Typically metrics.MetricsRegistry
+        // Collector provides the implementation for creating and managing metric instruments.
+        // Must implement metrics.MetricsRegistry. Required when metrics are enabled.
+        Collector any // Typically metrics.MetricsRegistry
 
 	// MiddlewareFactory creates the metrics middleware.
 	// Optional. If nil, SRouter likely uses a default factory. Must implement metrics.MiddlewareFactory.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -4,7 +4,7 @@ SRouter features a flexible, interface-based metrics system located in the `pkg/
 
 ## Enabling and Configuring Metrics
 
-Metrics collection is enabled by setting `EnableMetrics: true` in your `RouterConfig`. Further customization is done via the `MetricsConfig` field within `RouterConfig`.
+Metrics collection is enabled by providing a non-nil `MetricsConfig` in your `RouterConfig`.
 
 ```go
 import (
@@ -20,10 +20,9 @@ import (
 routerConfig := router.RouterConfig{
     Logger:            logger,
     // ... other global config ...
-    EnableMetrics:     true,      // Enable metrics collection
     MetricsConfig: &router.MetricsConfig{
         // Provide your implementations of metrics interfaces.
-        // Provide your implementation of the metrics.MetricsRegistry interface. Required if EnableMetrics is true.
+        // Provide your implementation of the metrics.MetricsRegistry interface. Required when metrics are enabled.
         Collector:        myMetricsRegistry, // Must implement metrics.MetricsRegistry
 
         // Provide your implementation of metrics.MetricsMiddleware. Optional.

--- a/pkg/router/logging_trace_test.go
+++ b/pkg/router/logging_trace_test.go
@@ -17,7 +17,7 @@ import (
 
 // --- Tests from trace_test.go ---
 
-// TestTraceIDLogging tests that trace IDs are included in log entries when EnableTraceID is true
+// TestTraceIDLogging tests that trace IDs are included in log entries when TraceIDBufferSize > 0
 func TestTraceIDLogging(t *testing.T) {
 	core, logs := observer.New(zap.DebugLevel)
 	logger := zap.New(core)
@@ -54,7 +54,7 @@ func TestTraceIDLogging(t *testing.T) {
 	}
 }
 
-// TestTraceIDLoggingDisabled tests that trace IDs are not included in log entries when EnableTraceID is false
+// TestTraceIDLoggingDisabled tests that trace IDs are not included in log entries when TraceIDBufferSize is 0
 func TestTraceIDLoggingDisabled(t *testing.T) {
 	core, logs := observer.New(zap.DebugLevel)
 	logger := zap.New(core)
@@ -83,7 +83,7 @@ func TestTraceIDLoggingDisabled(t *testing.T) {
 	// The previous loop checking for the absence of 'trace_id' is no longer needed.
 }
 
-// TestHandleErrorWithTraceID tests that handleError includes trace IDs in log entries when EnableTraceID is true
+// TestHandleErrorWithTraceID tests that handleError includes trace IDs in log entries when TraceIDBufferSize > 0
 func TestHandleErrorWithTraceID(t *testing.T) {
 	core, logs := observer.New(zap.ErrorLevel)
 	logger := zap.New(core)
@@ -118,7 +118,7 @@ func TestHandleErrorWithTraceID(t *testing.T) {
 	}
 }
 
-// TestHandleErrorWithoutTraceID tests that handleError does not include trace IDs in log entries when EnableTraceID is false
+// TestHandleErrorWithoutTraceID tests that handleError does not include trace IDs in log entries when TraceIDBufferSize is 0
 func TestHandleErrorWithoutTraceID(t *testing.T) {
 	core, logs := observer.New(zap.ErrorLevel)
 	logger := zap.New(core)
@@ -153,7 +153,7 @@ func TestHandleErrorWithoutTraceID(t *testing.T) {
 	}
 }
 
-// TestRecoveryMiddlewareWithTraceID tests that recoveryMiddleware includes trace IDs in log entries when EnableTraceID is true
+// TestRecoveryMiddlewareWithTraceID tests that recoveryMiddleware includes trace IDs in log entries when TraceIDBufferSize > 0
 func TestRecoveryMiddlewareWithTraceID(t *testing.T) {
 	core, logs := observer.New(zap.ErrorLevel)
 	logger := zap.New(core)
@@ -190,7 +190,7 @@ func TestRecoveryMiddlewareWithTraceID(t *testing.T) {
 	}
 }
 
-// TestRecoveryMiddlewareWithoutTraceID tests that recoveryMiddleware does not include trace IDs in log entries when EnableTraceID is false
+// TestRecoveryMiddlewareWithoutTraceID tests that recoveryMiddleware does not include trace IDs in log entries when TraceIDBufferSize is 0
 func TestRecoveryMiddlewareWithoutTraceID(t *testing.T) {
 	core, logs := observer.New(zap.ErrorLevel)
 	logger := zap.New(core)


### PR DESCRIPTION
## Summary
- update README snippet to use `TraceIDBufferSize`
- document enabling metrics via `MetricsConfig`
- remove `EnableMetrics` field from docs
- revise metrics documentation
- update test comments referencing removed config field

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.24.0.3:8080: connect: no route to host)*