### PR TITLE
Fix Basic Usage docs for refactored router API

### DIFF
--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -44,15 +44,15 @@ func main() {
 		GlobalTimeout:     2 * time.Second,
 		GlobalMaxBodySize: 1 << 20, // 1 MB
 		// Define sub-routers. Even top-level routes belong to a sub-router (e.g., with an empty prefix).
-		SubRouters: []router.SubRouterConfig{
-			{
-				PathPrefix: "", // Root-level routes
-				Routes: []any{ // Use 'any' slice to hold different route config types
-					helloRoute,
-					// Add more RouteConfigBase or GenericRouteRegistrationFunc here
-				},
-				// Middlewares specific to this sub-router can be added here
-			},
+                SubRouters: []router.SubRouterConfig{
+                        {
+                                PathPrefix: "", // Root-level routes
+                                Routes: []router.RouteDefinition{ // Holds RouteConfigBase or GenericRouteRegistrationFunc
+                                        helloRoute,
+                                        // Add more RouteConfigBase or GenericRouteRegistrationFunc here
+                                },
+                                // Middlewares specific to this sub-router can be added here
+                        },
 			// Add more sub-routers here (e.g., { PathPrefix: "/api/v1", Routes: [...] })
 		},
                 // Global middlewares can be added here
@@ -63,19 +63,23 @@ func main() {
 
 	// Define the authentication function (replace with your actual logic)
 	// This function is required by NewRouter, even if AuthLevel is NoAuth everywhere.
-	authFunction := func(ctx context.Context, token string) (string, bool) {
-		// Example: Check if token is "valid-token"
-		if token == "valid-token" {
-			return "user-id-from-token", true // Return user ID and true if valid
-		}
-		return "", false // Return empty string and false if invalid
-	}
+        authFunction := func(ctx context.Context, token string) (*string, bool) {
+                // Example: Check if token is "valid-token"
+                if token == "valid-token" {
+                        user := "user-id-from-token"
+                        return &user, true // Return user pointer and true if valid
+                }
+                return nil, false // Return nil and false if invalid
+        }
 
 	// Define a function to extract a comparable UserID from the User object (returned by authFunction)
 	// In this case, the User object is just a string (the user ID itself).
-	userIdFromUserFunction := func(user string) string {
-		return user
-	}
+        userIdFromUserFunction := func(user *string) string {
+                if user == nil {
+                        return ""
+                }
+                return *user
+        }
 
 	// Create the router. Routes are defined within the routerConfig.
 	// The type parameters define the UserID type (string) and User object type (string).
@@ -90,10 +94,10 @@ func main() {
 Key components:
 
 -   **`RouterConfig`**: Holds global settings like logger, timeouts, body size limits, and global middleware.
--   **`authFunction`**: A function `func(ctx context.Context, token string) (UserObjectType, bool)` that validates an authentication token (currently expects Bearer token) and returns the user object and a boolean indicating success. Used by the built-in middleware when `AuthLevel` is set.
--   **`userIdFromUserFunction`**: A function `func(user UserObjectType) UserIDType` that extracts the comparable User ID from the user object returned by `authFunction`. Used by the built-in middleware.
+-   **`authFunction`**: A function `func(ctx context.Context, token string) (*UserObjectType, bool)` that validates an authentication token (currently expects Bearer token) and returns a pointer to the user object and a boolean indicating success. Used by the built-in middleware when `AuthLevel` is set.
+-   **`userIdFromUserFunction`**: A function `func(user *UserObjectType) UserIDType` that extracts the comparable User ID from the user object returned by `authFunction`. Used by the built-in middleware.
 -   **`NewRouter[UserIDType, UserObjectType]`**: The constructor for the router. The type parameters define the type used for user IDs (`UserIDType`, must be comparable) and the type used for the user object (`UserObjectType`, can be any type) potentially stored in the context.
--   **`RouterConfig.SubRouters`**: A slice of `SubRouterConfig` where routes are defined. Each `SubRouterConfig` has a `PathPrefix` and a `Routes` slice.
+-   **`RouterConfig.SubRouters`**: A slice of `SubRouterConfig` where routes are defined. Each `SubRouterConfig` has a `PathPrefix` and a `Routes` slice of `router.RouteDefinition` values.
 -   **`RouteConfigBase` / `RouteConfig[T, U]`**: Structs used within the `SubRouterConfig.Routes` slice to define individual routes, their paths (relative to the sub-router prefix), methods, handlers, authentication levels, etc.
 
 See the [Authentication](./authentication.md) and [Configuration Reference](./configuration.md) sections for more details on these components.


### PR DESCRIPTION
## Summary
- update example to use RouteDefinition slice
- update authFunction and userIdFromUserFunction signatures to match the refactored API
- clarify RouterConfig.SubRouters bullet points

## Testing
- `go test ./...` *(fails: TestRegisterSubRouter_UnsupportedRouteType)*

------
https://chatgpt.com/codex/tasks/task_e_68437d5723fc8331bdfdfad89851fefd