### PR TITLE
Improve sanitizer warning details

### DIFF
--- a/pkg/router/route.go
+++ b/pkg/router/route.go
@@ -2,7 +2,9 @@ package router
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/Suhaibinator/SRouter/pkg/codec"
@@ -71,15 +73,15 @@ func RegisterGenericRoute[Req any, Resp any, UserID comparable, User any](
 ) {
 	// Warn if no sanitizer function is provided (only at registration time)
 	if route.Sanitizer == nil {
-		r.logger.Warn("Route registered without sanitizer function",
+		methods := make([]string, len(route.Methods))
+		for i, method := range route.Methods {
+			methods[i] = string(method)
+		}
+
+		r.logger.Warn(
+			fmt.Sprintf("Route registered without sanitizer function: %s %s", strings.Join(methods, ","), route.Path),
 			zap.String("path", route.Path),
-			zap.Strings("methods", func() []string {
-				methods := make([]string, len(route.Methods))
-				for i, method := range route.Methods {
-					methods[i] = string(method)
-				}
-				return methods
-			}()),
+			zap.Strings("methods", methods),
 		)
 	}
 


### PR DESCRIPTION
### Motivation
- The sanitizer registration warning lacked route-specific context, making it hard to identify which routes were missing a sanitizer.

### Description
- Updated `pkg/router/route.go` to compute a `methods` slice and include the HTTP methods and path directly in the warning message using `fmt.Sprintf` and `strings.Join`, while still emitting structured `zap` fields (`path` and `methods`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6983bdd5fa048323bd431ba9dab8431f)