### PR TITLE
feat(router)!: inherit sub-router overrides; add global auth token

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.26.1']
+        go-version: ['1.26.3']
         os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: true
 
@@ -60,7 +60,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.26.1'
+        go-version: '1.26.3'
         cache: true
 
     - name: Install golangci-lint
@@ -74,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ['1.26.1']
+        go-version: ['1.26.3']
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
@@ -100,7 +100,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.26.1'
+        go-version: '1.26.3'
         cache: true
 
     - name: Run benchmarks
@@ -116,7 +116,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.26.1'
+        go-version: '1.26.3'
         cache: true
 
     - name: Build simple example

--- a/README.md
+++ b/README.md
@@ -696,7 +696,7 @@ SRouter supports three authentication levels, specified in `RouteConfig` or `Rou
 2. **AuthOptional**: Authentication is attempted (e.g., by middleware). If successful, user info is added to the context. The request proceeds regardless.
 3. **AuthRequired**: Authentication is required (e.g., by middleware). If authentication fails, the middleware should reject the request (e.g., with 401 Unauthorized). If successful, user info is added to the context.
 
-When using the built-in `AuthOptional`/`AuthRequired` middleware, the token is extracted from the configured auth token source (`common.RouteOverrides.AuthToken`). The default source is the `Authorization` header. Cookie-based auth is supported by setting `AuthToken` to a cookie source on a sub-router or route.
+When using the built-in `AuthOptional`/`AuthRequired` middleware, the token is extracted from the configured auth token source. The default source is the `Authorization` header. Cookie-based auth can be enabled globally with `RouterConfig.GlobalAuthToken`, or overridden on a sub-router or route with `common.RouteOverrides.AuthToken`. Precedence is route override, current or inherited sub-router override, global config, then the built-in `Authorization` header default.
 
 ```go
 // Example route configurations
@@ -1180,6 +1180,7 @@ type RouterConfig struct {
  GlobalTimeout      time.Duration                     // Default response timeout for all routes
  GlobalMaxBodySize  int64                             // Default maximum request body size in bytes
  GlobalRateLimit    *common.RateLimitConfig[any, any] // Default rate limit for all routes (uses common.RateLimitConfig)
+ GlobalAuthToken    *common.AuthTokenConfig           // Default auth token source for built-in auth middleware
  IPConfig           *router.IPConfig                  // Configuration for client IP extraction (uses router.IPConfig)
  EnableTraceLogging bool                              // Enable detailed trace logging (default: false, uses Debug level)
 TraceLoggingUseInfo bool                             // Log traces at Info level instead of Debug (default: false)
@@ -1227,12 +1228,13 @@ type MetricsConfig struct {
 
 ```go
 type SubRouterConfig struct {
- PathPrefix string                            // Common path prefix for all routes in this sub-router
- Overrides  common.RouteOverrides             // Timeout/body size/rate limit overrides for this sub-router
- Routes     []RouteDefinition                 // Routes (RouteConfigBase or GenericRouteDefinition)
- Middlewares         []common.Middleware               // Middlewares applied to all routes in this sub-router
- SubRouters          []SubRouterConfig                 // Nested sub-routers
- AuthLevel           *AuthLevel                        // Default auth level for routes in this sub-router (nil inherits)
+ PathPrefix       string                // Common path prefix for all routes in this sub-router
+ Overrides        common.RouteOverrides // Timeout/body size/rate limit/auth token overrides for this sub-router
+ IsolateOverrides bool                  // Ignore parent sub-router overrides; globals still apply
+ Routes           []RouteDefinition     // Routes (RouteConfigBase or GenericRouteDefinition)
+ Middlewares      []common.Middleware   // Middlewares applied to all routes in this sub-router
+ SubRouters       []SubRouterConfig     // Nested sub-routers
+ AuthLevel        *AuthLevel            // Default auth level for routes in this sub-router (nil inherits)
  // CacheResponse, CacheKeyPrefix removed - implement caching via middleware if needed
 }
 ```

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -85,7 +85,16 @@ r := router.NewRouter[string, MyUserType](routerConfig, myAuthValidator, myGetID
 
 ## Auth Token Source
 
-By default, the built-in middleware reads the token from the `Authorization` header and trims a `Bearer ` prefix if present. You can override the source per sub-router or per route via `common.RouteOverrides.AuthToken`:
+By default, the built-in middleware reads the token from the `Authorization` header and trims a `Bearer ` prefix if present. You can set an application-wide source via `RouterConfig.GlobalAuthToken`, then override it per sub-router or per route via `common.RouteOverrides.AuthToken`:
+
+```go
+routerConfig := router.RouterConfig{
+    GlobalAuthToken: &common.AuthTokenConfig{
+        Source:     common.AuthTokenSourceCookie,
+        CookieName: "auth_token",
+    },
+}
+```
 
 ```go
 Overrides: common.RouteOverrides{
@@ -98,8 +107,11 @@ Overrides: common.RouteOverrides{
 
 Notes:
 - Only the configured source is honored (no fallback to other sources).
+- Auth token source precedence is route override, current or inherited sub-router override, global config, then the built-in `Authorization` header default.
+- Nested sub-routers inherit auth token overrides unless `SubRouterConfig.IsolateOverrides` is true.
 - If `Source` is `AuthTokenSourceHeader` and `HeaderName` is empty, it defaults to `Authorization`.
 - If `Source` is `AuthTokenSourceCookie` and `CookieName` is empty, the built-in middleware logs a warning at registration time.
+- If an `AuthRequired` route falls all the way back to the built-in default because no route, sub-router, or global auth token source is configured, SRouter logs a registration-time warning.
 
 ## Custom Authentication Middleware
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,6 +35,11 @@ type RouterConfig struct {
 	// Uses common.RateLimitConfig. Can be overridden. Nil means no global rate limit.
 	GlobalRateLimit *common.RateLimitConfig[any, any]
 
+	// GlobalAuthToken specifies the default auth token source for built-in auth middleware.
+	// Can be overridden by inherited sub-router or route overrides.
+	// Nil falls back to the built-in Authorization header default.
+	GlobalAuthToken *common.AuthTokenConfig
+
 	// IPConfig defines how client IP addresses are extracted.
 	// See docs/ip-configuration.md. Nil uses default (IPSourceXForwardedFor, TrustProxy: true).
 	IPConfig *IPConfig // Defined in router package
@@ -131,9 +136,13 @@ type SubRouterConfig struct {
         PathPrefix string
 
         // Overrides allows this sub-router to specify timeout, body size, rate limit,
-        // or auth token source settings that override the global configuration.
-        // settings that override the global configuration. Zero values mean no override.
+        // or auth token source settings. Nested sub-routers inherit these values
+        // unless they set IsolateOverrides.
         Overrides common.RouteOverrides
+
+        // IsolateOverrides prevents this sub-router from inheriting parent
+        // sub-router overrides. RouterConfig global defaults still apply.
+        IsolateOverrides bool
 
         // Routes is a slice containing route definitions. Must contain RouteConfigBase
         // or GenericRouteRegistrationFunc values.
@@ -191,7 +200,7 @@ type RouteConfigBase struct {
 
 ## `common.RouteOverrides` and Auth Token Source
 
-Route overrides control per-route and per-sub-router settings, including the auth token source used by the built-in authentication middleware.
+Route overrides control per-route and per-sub-router settings, including the auth token source used by the built-in authentication middleware. Nested sub-routers inherit parent overrides unless `SubRouterConfig.IsolateOverrides` is true. Effective precedence is route override, current or inherited sub-router override, `RouterConfig` global setting, then the field default.
 
 ```go
 package common

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -92,7 +92,8 @@ You can nest `SubRouterConfig` structs within the `SubRouters` field of another 
 
 **Important notes about nested sub-routers:**
 - Path prefixes are concatenated (e.g., `/api` + `/v1` = `/api/v1`)
-- Configuration overrides (timeout, max body size, rate limit) are **not inherited** - each sub-router level must explicitly set its own overrides
+- Configuration overrides (timeout, max body size, rate limit, auth token source) are inherited by nested sub-routers
+- Set `IsolateOverrides: true` on a sub-router to ignore parent sub-router overrides while still using `RouterConfig` globals
 - Middlewares are **additive** - they combine as you go deeper (global + parent sub-router + child sub-router + route)
 - The most specific setting takes precedence for overrides
 
@@ -111,7 +112,7 @@ usersV1SubRouter := router.SubRouterConfig{
 
 apiV1SubRouter := router.SubRouterConfig{
         PathPrefix: "/v1", // Relative to /api -> /api/v1
-        Overrides: common.RouteOverrides{Timeout: 3 * time.Second}, // Applies to routes in this sub-router only, NOT inherited by nested sub-routers
+        Overrides: common.RouteOverrides{Timeout: 3 * time.Second}, // Applies to routes in this sub-router and nested sub-routers
         SubRouters: []router.SubRouterConfig{usersV1SubRouter}, // Nest the users sub-router
         Routes: []router.RouteDefinition{
 		router.RouteConfigBase{ Path: "/status", Methods: []router.HttpMethod{router.MethodGet}, Handler: V1StatusHandler }, // /api/v1/status
@@ -141,7 +142,7 @@ r := router.NewRouter[string, string](routerConfig, authFunction, userIdFromUser
 ```
 
 **Configuration precedence:**
-- **Overrides** (timeouts, body size, rate limits, auth token source): The most specific setting wins (Route > Sub-Router > Global). Each level must explicitly set overrides; they are not inherited.
+- **Overrides** (timeouts, body size, rate limits, auth token source): The most specific setting wins (Route > current or inherited Sub-Router > Global > field default). Nested sub-routers inherit overrides unless `IsolateOverrides` is true.
 - **Middlewares**: These are combined additively in order: Global → Outer Sub-Router → Inner Sub-Router → Route-specific. All applicable middlewares run in this sequence.
 
 ### Imperative Route Registration

--- a/pkg/router/auth_middleware_test.go
+++ b/pkg/router/auth_middleware_test.go
@@ -50,7 +50,7 @@ func TestAuthOptionalMiddleware(t *testing.T) {
 	})
 
 	// Apply the authOptionalMiddleware to the test handler
-	middleware := router.authOptionalMiddleware(baseHandler)
+	middleware := router.authOptionalMiddlewareWithConfig(defaultAuthTokenConfig())(baseHandler)
 
 	// Test case 1: Request with valid auth header (checks context)
 	t.Run("with valid auth header", func(t *testing.T) {
@@ -81,7 +81,7 @@ func TestAuthOptionalMiddleware(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		})
 
-		validTokenMiddleware := router.authOptionalMiddleware(validTokenHandler)
+		validTokenMiddleware := router.authOptionalMiddlewareWithConfig(defaultAuthTokenConfig())(validTokenHandler)
 		validTokenMiddleware.ServeHTTP(rr, req)
 
 		if !handlerCalled {
@@ -152,7 +152,7 @@ func TestAuthRequiredMiddleware(t *testing.T) {
 		_, _ = w.Write([]byte("OK"))
 	})
 
-	wrappedHandler := r.authRequiredMiddleware(handler)
+	wrappedHandler := r.authRequiredMiddlewareWithConfig(defaultAuthTokenConfig())(handler)
 
 	// Test with no Authorization header
 	req, _ := http.NewRequest("GET", "/test", nil)
@@ -205,7 +205,7 @@ func TestAuthRequiredMiddleware(t *testing.T) {
 	debugCore, debugLogs := observer.New(zap.DebugLevel)
 	debugLogger := zap.New(debugCore)
 	r = NewRouter(RouterConfig{Logger: debugLogger}, mocks.MockAuthFunction, mocks.MockUserIDFromUser)
-	wrappedHandler = r.authRequiredMiddleware(handler) // Re-wrap with new router instance
+	wrappedHandler = r.authRequiredMiddlewareWithConfig(defaultAuthTokenConfig())(handler) // Re-wrap with new router instance
 
 	req, _ = http.NewRequest("GET", "/test", nil)
 	req.Header.Set("Authorization", "Bearer valid-token")
@@ -298,7 +298,7 @@ func TestAuthRequiredMiddlewareWithUserObject(t *testing.T) {
 		_, _ = w.Write([]byte("OK"))
 	})
 
-	wrappedHandler := router.authRequiredMiddleware(handler)
+	wrappedHandler := router.authRequiredMiddlewareWithConfig(defaultAuthTokenConfig())(handler)
 
 	// Test with valid Authorization header
 	req, _ := http.NewRequest("GET", "/test", nil)
@@ -368,7 +368,7 @@ func TestAuthRequiredMiddlewareWithTraceID(t *testing.T) {
 		_, _ = w.Write([]byte("OK"))
 	})
 
-	wrappedHandler := r.authRequiredMiddleware(handler)
+	wrappedHandler := r.authRequiredMiddlewareWithConfig(defaultAuthTokenConfig())(handler)
 
 	req, _ := http.NewRequest("GET", "/test", nil)
 	req.Header.Set("Authorization", "Bearer valid-token")

--- a/pkg/router/auth_token_config_test.go
+++ b/pkg/router/auth_token_config_test.go
@@ -1,9 +1,14 @@
 package router
 
 import (
+	"context"
+	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/Suhaibinator/SRouter/pkg/codec"
 	"github.com/Suhaibinator/SRouter/pkg/common"
 	"github.com/Suhaibinator/SRouter/pkg/router/internal/mocks"
 	"go.uber.org/zap"
@@ -88,4 +93,492 @@ func TestGetEffectiveAuthTokenConfigUsesSubRouter(t *testing.T) {
 	if config.HeaderName != defaultAuthHeaderName {
 		t.Fatalf("expected header name %q, got %q", defaultAuthHeaderName, config.HeaderName)
 	}
+}
+
+func TestGetEffectiveAuthTokenConfigUsesGlobal(t *testing.T) {
+	globalAuth := common.AuthTokenConfig{
+		Source:     common.AuthTokenSourceCookie,
+		CookieName: "auth_token",
+	}
+	r := NewRouter(RouterConfig{
+		Logger:          zap.NewNop(),
+		GlobalAuthToken: &globalAuth,
+	}, mocks.MockAuthFunction, mocks.MockUserIDFromUser)
+
+	config := r.getEffectiveAuthTokenConfig(nil, nil)
+	if config.Source != common.AuthTokenSourceCookie {
+		t.Fatalf("expected cookie auth source, got %v", config.Source)
+	}
+	if config.CookieName != "auth_token" {
+		t.Fatalf("expected cookie name %q, got %q", "auth_token", config.CookieName)
+	}
+}
+
+func TestAuthRequiredMiddlewareUsesGlobalAuthToken(t *testing.T) {
+	globalAuth := common.AuthTokenConfig{
+		Source:     common.AuthTokenSourceCookie,
+		CookieName: "auth_token",
+	}
+	r := NewRouter(RouterConfig{
+		Logger:          zap.NewNop(),
+		GlobalAuthToken: &globalAuth,
+	}, tokenAuthFunction, tokenUserIDFromUser)
+
+	handler := r.authRequiredMiddleware(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "/test", nil)
+	req.AddCookie(&http.Cookie{Name: "auth_token", Value: "valid-token"})
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rr.Code)
+	}
+}
+
+func TestGlobalAuthTokenCookieUsedAcrossRegistrationStyles(t *testing.T) {
+	globalAuth := common.AuthTokenConfig{
+		Source:     common.AuthTokenSourceCookie,
+		CookieName: "auth_token",
+	}
+	authLevel := authLevelPtr(AuthRequired)
+	r := NewRouter(RouterConfig{
+		Logger:          zap.NewNop(),
+		GlobalAuthToken: &globalAuth,
+		SubRouters: []SubRouterConfig{
+			{
+				PathPrefix: "/api",
+				Routes: []RouteDefinition{
+					RouteConfigBase{
+						Path:      "/sub",
+						Methods:   []HttpMethod{MethodGet},
+						AuthLevel: authLevel,
+						Handler:   okHandler,
+					},
+					NewGenericRouteDefinition[authTokenTestRequest, authTokenTestResponse, string, string](authTokenGenericRoute("/generic", authLevel)),
+				},
+				SubRouters: []SubRouterConfig{
+					{
+						PathPrefix: "/nested",
+						Routes: []RouteDefinition{
+							RouteConfigBase{
+								Path:      "/protected",
+								Methods:   []HttpMethod{MethodGet},
+								AuthLevel: authLevel,
+								Handler:   okHandler,
+							},
+						},
+					},
+				},
+			},
+			{PathPrefix: "/dynamic"},
+		},
+	}, tokenAuthFunction, tokenUserIDFromUser)
+
+	r.RegisterRoute(RouteConfigBase{
+		Path:      "/direct",
+		Methods:   []HttpMethod{MethodGet},
+		AuthLevel: authLevel,
+		Handler:   okHandler,
+	})
+	RegisterGenericRoute(r, authTokenGenericRoute("/direct-generic", authLevel), 0, 0, nil)
+
+	err := RegisterGenericRouteOnSubRouter(r, "/dynamic", authTokenGenericRoute("/generic", authLevel))
+	if err != nil {
+		t.Fatalf("RegisterGenericRouteOnSubRouter failed: %v", err)
+	}
+
+	tests := []struct {
+		method string
+		path   string
+		body   string
+	}{
+		{method: http.MethodGet, path: "/direct"},
+		{method: http.MethodPost, path: "/direct-generic", body: `{"name":"test"}`},
+		{method: http.MethodGet, path: "/api/sub"},
+		{method: http.MethodGet, path: "/api/nested/protected"},
+		{method: http.MethodPost, path: "/api/generic", body: `{"name":"test"}`},
+		{method: http.MethodPost, path: "/dynamic/generic", body: `{"name":"test"}`},
+	}
+
+	for _, tt := range tests {
+		req := httptest.NewRequest(tt.method, tt.path, strings.NewReader(tt.body))
+		req.Header.Set("Content-Type", "application/json")
+		req.AddCookie(&http.Cookie{Name: "auth_token", Value: "valid-token"})
+		rr := httptest.NewRecorder()
+
+		r.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("%s %s: expected status %d, got %d; body=%s", tt.method, tt.path, http.StatusOK, rr.Code, rr.Body.String())
+		}
+	}
+}
+
+func TestAuthTokenPrecedence(t *testing.T) {
+	globalAuth := common.AuthTokenConfig{Source: common.AuthTokenSourceCookie, CookieName: "global_token"}
+	parentAuth := common.AuthTokenConfig{Source: common.AuthTokenSourceCookie, CookieName: "parent_token"}
+	childAuth := common.AuthTokenConfig{Source: common.AuthTokenSourceCookie, CookieName: "child_token"}
+	subAuth := common.AuthTokenConfig{Source: common.AuthTokenSourceCookie, CookieName: "sub_token"}
+	routeAuth := common.AuthTokenConfig{Source: common.AuthTokenSourceHeader, HeaderName: "X-Route-Token"}
+	authLevel := authLevelPtr(AuthRequired)
+
+	r := NewRouter(RouterConfig{
+		Logger:          zap.NewNop(),
+		GlobalAuthToken: &globalAuth,
+		SubRouters: []SubRouterConfig{
+			{
+				PathPrefix: "/api",
+				Overrides:  common.RouteOverrides{AuthToken: &parentAuth},
+				Routes: []RouteDefinition{
+					RouteConfigBase{
+						Path:      "/route",
+						Methods:   []HttpMethod{MethodGet},
+						AuthLevel: authLevel,
+						Overrides: common.RouteOverrides{AuthToken: &routeAuth},
+						Handler:   okHandler,
+					},
+				},
+				SubRouters: []SubRouterConfig{
+					{
+						PathPrefix: "/sub",
+						Overrides:  common.RouteOverrides{AuthToken: &subAuth},
+						Routes: []RouteDefinition{
+							RouteConfigBase{
+								Path:      "/protected",
+								Methods:   []HttpMethod{MethodGet},
+								AuthLevel: authLevel,
+								Handler:   okHandler,
+							},
+						},
+					},
+					{
+						PathPrefix: "/child",
+						Overrides:  common.RouteOverrides{AuthToken: &childAuth},
+						Routes: []RouteDefinition{
+							RouteConfigBase{
+								Path:      "/protected",
+								Methods:   []HttpMethod{MethodGet},
+								AuthLevel: authLevel,
+								Handler:   okHandler,
+							},
+						},
+					},
+					{
+						PathPrefix: "/inherited",
+						Routes: []RouteDefinition{
+							RouteConfigBase{
+								Path:      "/protected",
+								Methods:   []HttpMethod{MethodGet},
+								AuthLevel: authLevel,
+								Handler:   okHandler,
+							},
+						},
+					},
+				},
+			},
+		},
+	}, tokenAuthFunction, tokenUserIDFromUser)
+	r.RegisterRoute(RouteConfigBase{
+		Path:      "/global",
+		Methods:   []HttpMethod{MethodGet},
+		AuthLevel: authLevel,
+		Handler:   okHandler,
+	})
+
+	tests := []struct {
+		name       string
+		path       string
+		headerName string
+		cookieName string
+	}{
+		{name: "route beats sub-router", path: "/api/route", headerName: "X-Route-Token"},
+		{name: "sub-router beats inherited parent", path: "/api/sub/protected", cookieName: "sub_token"},
+		{name: "child sub-router beats inherited parent", path: "/api/child/protected", cookieName: "child_token"},
+		{name: "parent sub-router inherits into child", path: "/api/inherited/protected", cookieName: "parent_token"},
+		{name: "global beats built-in default", path: "/global", cookieName: "global_token"},
+	}
+
+	for _, tt := range tests {
+		req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+		if tt.headerName != "" {
+			req.Header.Set(tt.headerName, "Bearer valid-token")
+		}
+		if tt.cookieName != "" {
+			req.AddCookie(&http.Cookie{Name: tt.cookieName, Value: "valid-token"})
+		}
+		rr := httptest.NewRecorder()
+
+		r.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Fatalf("%s: expected status %d, got %d; body=%s", tt.name, http.StatusOK, rr.Code, rr.Body.String())
+		}
+	}
+}
+
+func TestIsolateOverridesPreventsParentAuthInheritanceButKeepsGlobal(t *testing.T) {
+	globalAuth := common.AuthTokenConfig{Source: common.AuthTokenSourceCookie, CookieName: "global_token"}
+	parentAuth := common.AuthTokenConfig{Source: common.AuthTokenSourceCookie, CookieName: "parent_token"}
+	authLevel := authLevelPtr(AuthRequired)
+
+	r := NewRouter(RouterConfig{
+		Logger:          zap.NewNop(),
+		GlobalAuthToken: &globalAuth,
+		SubRouters: []SubRouterConfig{
+			{
+				PathPrefix: "/api",
+				Overrides:  common.RouteOverrides{AuthToken: &parentAuth},
+				SubRouters: []SubRouterConfig{
+					{
+						PathPrefix:       "/isolated",
+						IsolateOverrides: true,
+						Routes: []RouteDefinition{
+							RouteConfigBase{
+								Path:      "/protected",
+								Methods:   []HttpMethod{MethodGet},
+								AuthLevel: authLevel,
+								Handler:   okHandler,
+							},
+						},
+					},
+				},
+			},
+		},
+	}, tokenAuthFunction, tokenUserIDFromUser)
+
+	reqParent := httptest.NewRequest(http.MethodGet, "/api/isolated/protected", nil)
+	reqParent.AddCookie(&http.Cookie{Name: "parent_token", Value: "valid-token"})
+	rrParent := httptest.NewRecorder()
+	r.ServeHTTP(rrParent, reqParent)
+	if rrParent.Code != http.StatusUnauthorized {
+		t.Fatalf("expected parent cookie to be ignored with status %d, got %d", http.StatusUnauthorized, rrParent.Code)
+	}
+
+	reqGlobal := httptest.NewRequest(http.MethodGet, "/api/isolated/protected", nil)
+	reqGlobal.AddCookie(&http.Cookie{Name: "global_token", Value: "valid-token"})
+	rrGlobal := httptest.NewRecorder()
+	r.ServeHTTP(rrGlobal, reqGlobal)
+	if rrGlobal.Code != http.StatusOK {
+		t.Fatalf("expected global cookie to pass with status %d, got %d", http.StatusOK, rrGlobal.Code)
+	}
+}
+
+func TestAuthRequiredBuiltInFallbackWarning(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	NewRouter(RouterConfig{
+		Logger: logger,
+		SubRouters: []SubRouterConfig{
+			{
+				PathPrefix: "/api",
+				Routes: []RouteDefinition{
+					RouteConfigBase{
+						Path:      "/protected",
+						Methods:   []HttpMethod{MethodGet},
+						AuthLevel: authLevelPtr(AuthRequired),
+						Handler:   okHandler,
+					},
+				},
+			},
+		},
+	}, tokenAuthFunction, tokenUserIDFromUser)
+
+	entries := logs.FilterMessage("Auth-required route using built-in default auth token source").All()
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 built-in fallback warning, got %d", len(entries))
+	}
+	if entries[0].ContextMap()["path"] != "/api/protected" {
+		t.Fatalf("expected path field %q, got %v", "/api/protected", entries[0].ContextMap()["path"])
+	}
+	if entries[0].ContextMap()["header_name"] != defaultAuthHeaderName {
+		t.Fatalf("expected header_name field %q, got %v", defaultAuthHeaderName, entries[0].ContextMap()["header_name"])
+	}
+}
+
+func TestNoBuiltInFallbackWarningWhenNotRisky(t *testing.T) {
+	core, logs := observer.New(zap.WarnLevel)
+	logger := zap.New(core)
+
+	NewRouter(RouterConfig{
+		Logger: logger,
+		SubRouters: []SubRouterConfig{{
+			PathPrefix: "/api",
+			Routes: []RouteDefinition{
+				RouteConfigBase{
+					Path:      "/optional",
+					Methods:   []HttpMethod{MethodGet},
+					AuthLevel: authLevelPtr(AuthOptional),
+					Handler:   okHandler,
+				},
+				RouteConfigBase{
+					Path:      "/public",
+					Methods:   []HttpMethod{MethodGet},
+					AuthLevel: authLevelPtr(NoAuth),
+					Handler:   okHandler,
+				},
+			},
+		}},
+	}, tokenAuthFunction, tokenUserIDFromUser)
+
+	entries := logs.FilterMessage("Auth-required route using built-in default auth token source").All()
+	if len(entries) != 0 {
+		t.Fatalf("expected no built-in fallback warnings for optional/noauth routes, got %d", len(entries))
+	}
+
+	globalAuth := common.AuthTokenConfig{Source: common.AuthTokenSourceHeader}
+	routeAuth := common.AuthTokenConfig{Source: common.AuthTokenSourceHeader, HeaderName: "X-Route-Token"}
+	subRouterAuth := common.AuthTokenConfig{Source: common.AuthTokenSourceCookie, CookieName: "sub_token"}
+	for _, tt := range []struct {
+		name   string
+		config RouterConfig
+	}{
+		{
+			name: "global auth token",
+			config: RouterConfig{
+				Logger:          logger,
+				GlobalAuthToken: &globalAuth,
+				SubRouters: []SubRouterConfig{{
+					PathPrefix: "/api",
+					Routes: []RouteDefinition{RouteConfigBase{
+						Path:      "/required",
+						Methods:   []HttpMethod{MethodGet},
+						AuthLevel: authLevelPtr(AuthRequired),
+						Handler:   okHandler,
+					}},
+				}},
+			},
+		},
+		{
+			name: "sub-router auth token",
+			config: RouterConfig{
+				Logger: logger,
+				SubRouters: []SubRouterConfig{{
+					PathPrefix: "/api",
+					Overrides:  common.RouteOverrides{AuthToken: &subRouterAuth},
+					Routes: []RouteDefinition{RouteConfigBase{
+						Path:      "/required",
+						Methods:   []HttpMethod{MethodGet},
+						AuthLevel: authLevelPtr(AuthRequired),
+						Handler:   okHandler,
+					}},
+				}},
+			},
+		},
+		{
+			name: "route auth token",
+			config: RouterConfig{
+				Logger: logger,
+				SubRouters: []SubRouterConfig{{
+					PathPrefix: "/api",
+					Routes: []RouteDefinition{RouteConfigBase{
+						Path:      "/required",
+						Methods:   []HttpMethod{MethodGet},
+						AuthLevel: authLevelPtr(AuthRequired),
+						Overrides: common.RouteOverrides{AuthToken: &routeAuth},
+						Handler:   okHandler,
+					}},
+				}},
+			},
+		},
+	} {
+		before := len(logs.FilterMessage("Auth-required route using built-in default auth token source").All())
+		NewRouter(tt.config, tokenAuthFunction, tokenUserIDFromUser)
+		after := len(logs.FilterMessage("Auth-required route using built-in default auth token source").All())
+		if after != before {
+			t.Fatalf("%s: expected no built-in fallback warning, got %d new warnings", tt.name, after-before)
+		}
+	}
+}
+
+func TestResolveSubRouterOverridesInheritsAndIsolates(t *testing.T) {
+	parentRateLimit := &common.RateLimitConfig[any, any]{Limit: 10, Window: time.Minute}
+	childRateLimit := &common.RateLimitConfig[any, any]{Limit: 20, Window: time.Minute}
+	parentAuth := &common.AuthTokenConfig{Source: common.AuthTokenSourceCookie, CookieName: "parent_token"}
+	childAuth := &common.AuthTokenConfig{Source: common.AuthTokenSourceCookie, CookieName: "child_token"}
+
+	parent := common.RouteOverrides{
+		Timeout:     time.Second,
+		MaxBodySize: 100,
+		RateLimit:   parentRateLimit,
+		AuthToken:   parentAuth,
+	}
+
+	inherited := resolveSubRouterOverrides(parent, SubRouterConfig{})
+	if inherited.Timeout != parent.Timeout {
+		t.Fatalf("expected inherited timeout %v, got %v", parent.Timeout, inherited.Timeout)
+	}
+	if inherited.MaxBodySize != parent.MaxBodySize {
+		t.Fatalf("expected inherited max body size %d, got %d", parent.MaxBodySize, inherited.MaxBodySize)
+	}
+	if inherited.RateLimit != parentRateLimit {
+		t.Fatal("expected inherited rate limit")
+	}
+	if inherited.AuthToken != parentAuth {
+		t.Fatal("expected inherited auth token")
+	}
+
+	overridden := resolveSubRouterOverrides(parent, SubRouterConfig{
+		Overrides: common.RouteOverrides{
+			Timeout:     2 * time.Second,
+			MaxBodySize: 200,
+			RateLimit:   childRateLimit,
+			AuthToken:   childAuth,
+		},
+	})
+	if overridden.Timeout != 2*time.Second || overridden.MaxBodySize != 200 || overridden.RateLimit != childRateLimit || overridden.AuthToken != childAuth {
+		t.Fatalf("expected child overrides to win, got %+v", overridden)
+	}
+
+	isolated := resolveSubRouterOverrides(parent, SubRouterConfig{IsolateOverrides: true})
+	if isolated.Timeout != 0 || isolated.MaxBodySize != 0 || isolated.RateLimit != nil || isolated.AuthToken != nil {
+		t.Fatalf("expected isolated overrides to start empty, got %+v", isolated)
+	}
+}
+
+type authTokenTestRequest struct {
+	Name string `json:"name"`
+}
+
+type authTokenTestResponse struct {
+	Message string `json:"message"`
+}
+
+func authTokenGenericRoute(path string, authLevel *AuthLevel) RouteConfig[authTokenTestRequest, authTokenTestResponse] {
+	return RouteConfig[authTokenTestRequest, authTokenTestResponse]{
+		Path:       path,
+		Methods:    []HttpMethod{MethodPost},
+		AuthLevel:  authLevel,
+		Codec:      codec.NewJSONCodec[authTokenTestRequest, authTokenTestResponse](),
+		SourceType: Body,
+		Handler: func(req *http.Request, data authTokenTestRequest) (authTokenTestResponse, error) {
+			return authTokenTestResponse{Message: data.Name}, nil
+		},
+	}
+}
+
+func tokenAuthFunction(ctx context.Context, token string) (*string, bool) {
+	if token == "valid-token" {
+		user := "user"
+		return &user, true
+	}
+	return nil, false
+}
+
+func tokenUserIDFromUser(user *string) string {
+	if user == nil {
+		return ""
+	}
+	return *user
+}
+
+func authLevelPtr(level AuthLevel) *AuthLevel {
+	return &level
+}
+
+func okHandler(w http.ResponseWriter, req *http.Request) {
+	w.WriteHeader(http.StatusOK)
 }

--- a/pkg/router/auth_token_config_test.go
+++ b/pkg/router/auth_token_config_test.go
@@ -89,7 +89,7 @@ func TestGetEffectiveAuthTokenConfigUsesSubRouter(t *testing.T) {
 		Source: common.AuthTokenSourceHeader,
 	}
 
-	config := r.getEffectiveAuthTokenConfig(nil, &subRouterAuth)
+	config := r.getEffectiveAuthTokenConfigWithOrigin(nil, &subRouterAuth).config
 	if config.HeaderName != defaultAuthHeaderName {
 		t.Fatalf("expected header name %q, got %q", defaultAuthHeaderName, config.HeaderName)
 	}
@@ -105,7 +105,7 @@ func TestGetEffectiveAuthTokenConfigUsesGlobal(t *testing.T) {
 		GlobalAuthToken: &globalAuth,
 	}, mocks.MockAuthFunction, mocks.MockUserIDFromUser)
 
-	config := r.getEffectiveAuthTokenConfig(nil, nil)
+	config := r.getEffectiveAuthTokenConfigWithOrigin(nil, nil).config
 	if config.Source != common.AuthTokenSourceCookie {
 		t.Fatalf("expected cookie auth source, got %v", config.Source)
 	}
@@ -114,36 +114,12 @@ func TestGetEffectiveAuthTokenConfigUsesGlobal(t *testing.T) {
 	}
 }
 
-func TestAuthRequiredMiddlewareUsesGlobalAuthToken(t *testing.T) {
-	globalAuth := common.AuthTokenConfig{
-		Source:     common.AuthTokenSourceCookie,
-		CookieName: "auth_token",
-	}
-	r := NewRouter(RouterConfig{
-		Logger:          zap.NewNop(),
-		GlobalAuthToken: &globalAuth,
-	}, tokenAuthFunction, tokenUserIDFromUser)
-
-	handler := r.authRequiredMiddleware(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}))
-
-	req := httptest.NewRequest(http.MethodGet, "/test", nil)
-	req.AddCookie(&http.Cookie{Name: "auth_token", Value: "valid-token"})
-	rr := httptest.NewRecorder()
-	handler.ServeHTTP(rr, req)
-
-	if rr.Code != http.StatusOK {
-		t.Fatalf("expected status %d, got %d", http.StatusOK, rr.Code)
-	}
-}
-
 func TestGlobalAuthTokenCookieUsedAcrossRegistrationStyles(t *testing.T) {
 	globalAuth := common.AuthTokenConfig{
 		Source:     common.AuthTokenSourceCookie,
 		CookieName: "auth_token",
 	}
-	authLevel := authLevelPtr(AuthRequired)
+	authLevel := new(AuthRequired)
 	r := NewRouter(RouterConfig{
 		Logger:          zap.NewNop(),
 		GlobalAuthToken: &globalAuth,
@@ -223,7 +199,7 @@ func TestAuthTokenPrecedence(t *testing.T) {
 	childAuth := common.AuthTokenConfig{Source: common.AuthTokenSourceCookie, CookieName: "child_token"}
 	subAuth := common.AuthTokenConfig{Source: common.AuthTokenSourceCookie, CookieName: "sub_token"}
 	routeAuth := common.AuthTokenConfig{Source: common.AuthTokenSourceHeader, HeaderName: "X-Route-Token"}
-	authLevel := authLevelPtr(AuthRequired)
+	authLevel := new(AuthRequired)
 
 	r := NewRouter(RouterConfig{
 		Logger:          zap.NewNop(),
@@ -322,7 +298,7 @@ func TestAuthTokenPrecedence(t *testing.T) {
 func TestIsolateOverridesPreventsParentAuthInheritanceButKeepsGlobal(t *testing.T) {
 	globalAuth := common.AuthTokenConfig{Source: common.AuthTokenSourceCookie, CookieName: "global_token"}
 	parentAuth := common.AuthTokenConfig{Source: common.AuthTokenSourceCookie, CookieName: "parent_token"}
-	authLevel := authLevelPtr(AuthRequired)
+	authLevel := new(AuthRequired)
 
 	r := NewRouter(RouterConfig{
 		Logger:          zap.NewNop(),
@@ -379,7 +355,7 @@ func TestAuthRequiredBuiltInFallbackWarning(t *testing.T) {
 					RouteConfigBase{
 						Path:      "/protected",
 						Methods:   []HttpMethod{MethodGet},
-						AuthLevel: authLevelPtr(AuthRequired),
+						AuthLevel: new(AuthRequired),
 						Handler:   okHandler,
 					},
 				},
@@ -411,13 +387,13 @@ func TestNoBuiltInFallbackWarningWhenNotRisky(t *testing.T) {
 				RouteConfigBase{
 					Path:      "/optional",
 					Methods:   []HttpMethod{MethodGet},
-					AuthLevel: authLevelPtr(AuthOptional),
+					AuthLevel: new(AuthOptional),
 					Handler:   okHandler,
 				},
 				RouteConfigBase{
 					Path:      "/public",
 					Methods:   []HttpMethod{MethodGet},
-					AuthLevel: authLevelPtr(NoAuth),
+					AuthLevel: new(NoAuth),
 					Handler:   okHandler,
 				},
 			},
@@ -446,7 +422,7 @@ func TestNoBuiltInFallbackWarningWhenNotRisky(t *testing.T) {
 					Routes: []RouteDefinition{RouteConfigBase{
 						Path:      "/required",
 						Methods:   []HttpMethod{MethodGet},
-						AuthLevel: authLevelPtr(AuthRequired),
+						AuthLevel: new(AuthRequired),
 						Handler:   okHandler,
 					}},
 				}},
@@ -462,7 +438,7 @@ func TestNoBuiltInFallbackWarningWhenNotRisky(t *testing.T) {
 					Routes: []RouteDefinition{RouteConfigBase{
 						Path:      "/required",
 						Methods:   []HttpMethod{MethodGet},
-						AuthLevel: authLevelPtr(AuthRequired),
+						AuthLevel: new(AuthRequired),
 						Handler:   okHandler,
 					}},
 				}},
@@ -477,7 +453,7 @@ func TestNoBuiltInFallbackWarningWhenNotRisky(t *testing.T) {
 					Routes: []RouteDefinition{RouteConfigBase{
 						Path:      "/required",
 						Methods:   []HttpMethod{MethodGet},
-						AuthLevel: authLevelPtr(AuthRequired),
+						AuthLevel: new(AuthRequired),
 						Overrides: common.RouteOverrides{AuthToken: &routeAuth},
 						Handler:   okHandler,
 					}},
@@ -573,10 +549,6 @@ func tokenUserIDFromUser(user *string) string {
 		return ""
 	}
 	return *user
-}
-
-func authLevelPtr(level AuthLevel) *AuthLevel {
-	return &level
 }
 
 func okHandler(w http.ResponseWriter, req *http.Request) {

--- a/pkg/router/config.go
+++ b/pkg/router/config.go
@@ -129,6 +129,7 @@ type RouterConfig struct {
 	GlobalTimeout       time.Duration                     // Default response timeout for all routes
 	GlobalMaxBodySize   int64                             // Default maximum request body size in bytes
 	GlobalRateLimit     *common.RateLimitConfig[any, any] // Use common.RateLimitConfig // Default rate limit for all routes
+	GlobalAuthToken     *common.AuthTokenConfig           // Default auth token source for built-in auth middleware
 	IPConfig            *IPConfig                         // Configuration for client IP extraction
 	EnableTraceLogging  bool                              // Enable trace logging
 	TraceLoggingUseInfo bool                              // Use Info level for trace logging
@@ -166,17 +167,18 @@ func (GenericRouteRegistrationFunc[T, U]) isRouteDefinition() {}
 //
 // Important behaviors:
 // - Path prefixes are concatenated when nesting (e.g., "/api" + "/v1" = "/api/v1")
-// - Configuration overrides (timeout, max body size, rate limit) are NOT inherited by nested sub-routers
+// - Configuration overrides are inherited by nested sub-routers unless IsolateOverrides is true
 // - Middlewares are additive - they combine with parent and global middlewares
 // - Routes can be added declaratively via the Routes field or imperatively after router creation
 type SubRouterConfig struct {
-	PathPrefix  string                // Common path prefix for all routes in this sub-router
-	Overrides   common.RouteOverrides // Configuration overrides for routes in this sub-router (not inherited by nested sub-routers)
-	Routes      []RouteDefinition     // Routes in this sub-router. Can contain RouteConfigBase or GenericRouteRegistrationFunc
-	Middlewares []common.Middleware   // Middlewares applied to all routes in this sub-router (additive with global middlewares)
+	PathPrefix       string                // Common path prefix for all routes in this sub-router
+	Overrides        common.RouteOverrides // Configuration overrides for routes in this sub-router
+	IsolateOverrides bool                  // If true, nested override inheritance starts fresh at this sub-router
+	Routes           []RouteDefinition     // Routes in this sub-router. Can contain RouteConfigBase or GenericRouteRegistrationFunc
+	Middlewares      []common.Middleware   // Middlewares applied to all routes in this sub-router (additive with global middlewares)
 	// SubRouters is a slice of nested sub-routers.
-	// Nested sub-routers inherit the parent's path prefix (concatenated) but NOT configuration overrides.
-	// Each nested sub-router must explicitly set its own overrides if needed.
+	// Nested sub-routers inherit the parent's path prefix (concatenated) and configuration overrides
+	// unless IsolateOverrides is set on the nested sub-router.
 	SubRouters []SubRouterConfig // Nested sub-routers with concatenated path prefixes
 	AuthLevel  *AuthLevel        // Default authentication level for all routes in this sub-router (overridden by route-specific AuthLevel)
 }

--- a/pkg/router/route.go
+++ b/pkg/router/route.go
@@ -35,10 +35,11 @@ func (r *Router[T, U]) RegisterRoute(route RouteConfigBase) {
 	// Pass the specific route config (which is *common.RateLimitConfig[any, any])
 	// to getEffectiveRateLimit. The conversion happens inside getEffectiveRateLimit.
 	rateLimit := r.getEffectiveRateLimit(route.Overrides.RateLimit, nil)
-	authTokenConfig := r.getEffectiveAuthTokenConfig(route.Overrides.AuthToken, nil)
+	authTokenResolution := r.getEffectiveAuthTokenConfigWithOrigin(route.Overrides.AuthToken, nil)
+	r.warnOnBuiltinAuthTokenFallback(route.Path, route.Methods, route.AuthLevel, authTokenResolution)
 
 	// Create a handler with all middlewares applied
-	handler := r.wrapHandler(route.Handler, route.AuthLevel, authTokenConfig, timeout, maxBodySize, rateLimit, route.Middlewares)
+	handler := r.wrapHandler(route.Handler, route.AuthLevel, authTokenResolution.config, timeout, maxBodySize, rateLimit, route.Middlewares)
 
 	// Register the route with httprouter
 	for _, method := range route.Methods {
@@ -68,6 +69,18 @@ func RegisterGenericRoute[Req any, Resp any, UserID comparable, User any](
 	effectiveTimeout time.Duration,
 	effectiveMaxBodySize int64,
 	effectiveRateLimit *common.RateLimitConfig[UserID, User], // Use common.RateLimitConfig
+) {
+	authTokenResolution := r.getEffectiveAuthTokenConfigWithOrigin(route.Overrides.AuthToken, nil)
+	registerGenericRouteWithAuthTokenResolution(r, route, effectiveTimeout, effectiveMaxBodySize, effectiveRateLimit, authTokenResolution)
+}
+
+func registerGenericRouteWithAuthTokenResolution[Req any, Resp any, UserID comparable, User any](
+	r *Router[UserID, User],
+	route RouteConfig[Req, Resp],
+	effectiveTimeout time.Duration,
+	effectiveMaxBodySize int64,
+	effectiveRateLimit *common.RateLimitConfig[UserID, User],
+	authTokenResolution authTokenConfigResolution,
 ) {
 	// Warn if no sanitizer function is provided (only at registration time)
 	if route.Sanitizer == nil {
@@ -272,8 +285,8 @@ func RegisterGenericRoute[Req any, Resp any, UserID comparable, User any](
 	})
 
 	// Create a handler with all middlewares applied, using the effective settings passed in
-	authTokenConfig := r.getEffectiveAuthTokenConfig(route.Overrides.AuthToken, nil)
-	wrappedHandler := r.wrapHandler(handler, route.AuthLevel, authTokenConfig, effectiveTimeout, effectiveMaxBodySize, effectiveRateLimit, route.Middlewares)
+	r.warnOnBuiltinAuthTokenFallback(route.Path, route.Methods, route.AuthLevel, authTokenResolution)
+	wrappedHandler := r.wrapHandler(handler, route.AuthLevel, authTokenResolution.config, effectiveTimeout, effectiveMaxBodySize, effectiveRateLimit, route.Middlewares)
 
 	// Register the route with httprouter
 	for _, method := range route.Methods {
@@ -323,10 +336,10 @@ func NewGenericRouteDefinition[Req any, Resp any, UserID comparable, User any](
 		// Pass the specific route config (which is *common.RateLimitConfig[any, any])
 		// to getEffectiveRateLimit. The conversion happens inside getEffectiveRateLimit.
 		effectiveRateLimit := r.getEffectiveRateLimit(route.Overrides.RateLimit, sr.Overrides.RateLimit)
-		effectiveAuthTokenConfig := r.getEffectiveAuthTokenConfig(route.Overrides.AuthToken, sr.Overrides.AuthToken)
-		finalRouteConfig.Overrides.AuthToken = &effectiveAuthTokenConfig
+		effectiveAuthTokenResolution := r.getEffectiveAuthTokenConfigWithOrigin(route.Overrides.AuthToken, sr.Overrides.AuthToken)
+		finalRouteConfig.Overrides.AuthToken = &effectiveAuthTokenResolution.config
 
 		// Call the underlying generic registration function with the modified config and effective settings
-		RegisterGenericRoute(r, finalRouteConfig, effectiveTimeout, effectiveMaxBodySize, effectiveRateLimit)
+		registerGenericRouteWithAuthTokenResolution(r, finalRouteConfig, effectiveTimeout, effectiveMaxBodySize, effectiveRateLimit, effectiveAuthTokenResolution)
 	}
 }

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -1424,9 +1424,15 @@ func (r *Router[T, U]) authenticateRequest(req *http.Request, extractToken authT
 	return req, false, "invalid token"
 }
 
-// authRequiredMiddleware is a middleware that requires authentication for a request.
-// If authentication fails, it returns a 401 Unauthorized response.
-// It uses the middleware.AuthenticationWithUser function with a configurable authentication function.
+// authRequiredMiddleware wraps next with authentication using the router's
+// effective default auth token config (RouterConfig.GlobalAuthToken, or the
+// built-in Authorization header default when unset). It returns 401 Unauthorized
+// when authentication fails.
+//
+// Route registration calls authRequiredMiddlewareWithConfig directly so it can
+// honor per-route and per-sub-router AuthToken overrides; this no-config form is
+// the default-config entry point (used in tests and by callers that only need
+// the router-wide default).
 func (r *Router[T, U]) authRequiredMiddleware(next http.Handler) http.Handler {
 	return r.authRequiredMiddlewareWithConfig(r.getEffectiveAuthTokenConfig(nil, nil))(next)
 }
@@ -1459,10 +1465,15 @@ func (r *Router[T, U]) authRequiredMiddlewareWithConfig(authTokenConfig common.A
 	}
 }
 
-// authOptionalMiddleware is a middleware that attempts authentication for a request,
-// but allows the request to proceed even if authentication fails.
-// It tries to authenticate the request and adds the user ID to the context if successful,
-// but allows the request to proceed even if authentication fails.
+// authOptionalMiddleware wraps next with optional authentication using the
+// router's effective default auth token config (RouterConfig.GlobalAuthToken, or
+// the built-in Authorization header default when unset). On success it adds the
+// user to the context; the request proceeds regardless of the outcome.
+//
+// Route registration calls authOptionalMiddlewareWithConfig directly so it can
+// honor per-route and per-sub-router AuthToken overrides; this no-config form is
+// the default-config entry point (used in tests and by callers that only need
+// the router-wide default).
 func (r *Router[T, U]) authOptionalMiddleware(next http.Handler) http.Handler {
 	return r.authOptionalMiddlewareWithConfig(r.getEffectiveAuthTokenConfig(nil, nil))(next)
 }

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -1098,16 +1098,13 @@ func buildAuthTokenExtractor(config common.AuthTokenConfig) authTokenExtractor {
 	}
 }
 
-// getEffectiveAuthTokenConfig returns the effective auth token config for a route.
+// getEffectiveAuthTokenConfigWithOrigin returns the effective auth token config
+// for a route along with the origin it was resolved from.
 // Precedence order (first non-nil value wins):
 // 1. Route-specific auth token config
 // 2. Sub-router auth token override
 // 3. Global auth token config from RouterConfig
 // 4. Default header-based auth token config
-func (r *Router[T, U]) getEffectiveAuthTokenConfig(routeAuth, subRouterAuth *common.AuthTokenConfig) common.AuthTokenConfig {
-	return r.getEffectiveAuthTokenConfigWithOrigin(routeAuth, subRouterAuth).config
-}
-
 func (r *Router[T, U]) getEffectiveAuthTokenConfigWithOrigin(routeAuth, subRouterAuth *common.AuthTokenConfig) authTokenConfigResolution {
 	if routeAuth != nil {
 		return authTokenConfigResolution{
@@ -1424,19 +1421,6 @@ func (r *Router[T, U]) authenticateRequest(req *http.Request, extractToken authT
 	return req, false, "invalid token"
 }
 
-// authRequiredMiddleware wraps next with authentication using the router's
-// effective default auth token config (RouterConfig.GlobalAuthToken, or the
-// built-in Authorization header default when unset). It returns 401 Unauthorized
-// when authentication fails.
-//
-// Route registration calls authRequiredMiddlewareWithConfig directly so it can
-// honor per-route and per-sub-router AuthToken overrides; this no-config form is
-// the default-config entry point (used in tests and by callers that only need
-// the router-wide default).
-func (r *Router[T, U]) authRequiredMiddleware(next http.Handler) http.Handler {
-	return r.authRequiredMiddlewareWithConfig(r.getEffectiveAuthTokenConfig(nil, nil))(next)
-}
-
 func (r *Router[T, U]) authRequiredMiddlewareWithConfig(authTokenConfig common.AuthTokenConfig) common.Middleware {
 	authTokenConfig = normalizeAuthTokenConfig(authTokenConfig)
 	r.warnOnInvalidAuthTokenConfig(authTokenConfig)
@@ -1463,19 +1447,6 @@ func (r *Router[T, U]) authRequiredMiddlewareWithConfig(authTokenConfig common.A
 			next.ServeHTTP(w, req)
 		})
 	}
-}
-
-// authOptionalMiddleware wraps next with optional authentication using the
-// router's effective default auth token config (RouterConfig.GlobalAuthToken, or
-// the built-in Authorization header default when unset). On success it adds the
-// user to the context; the request proceeds regardless of the outcome.
-//
-// Route registration calls authOptionalMiddlewareWithConfig directly so it can
-// honor per-route and per-sub-router AuthToken overrides; this no-config form is
-// the default-config entry point (used in tests and by callers that only need
-// the router-wide default).
-func (r *Router[T, U]) authOptionalMiddleware(next http.Handler) http.Handler {
-	return r.authOptionalMiddlewareWithConfig(r.getEffectiveAuthTokenConfig(nil, nil))(next)
 }
 
 func (r *Router[T, U]) authOptionalMiddlewareWithConfig(authTokenConfig common.AuthTokenConfig) common.Middleware {

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -59,7 +59,7 @@ type authTokenExtractor func(*http.Request) (string, bool, string)
 //
 // Important behaviors:
 // - Path prefixes are concatenated (parent + child)
-// - Configuration overrides are NOT inherited - the child must set its own
+// - Configuration overrides are inherited unless the child sets IsolateOverrides
 // - Middlewares will be combined additively when routes are registered
 // - This modifies the parent SubRouterConfig by appending to its SubRouters slice
 //
@@ -182,7 +182,7 @@ func NewRouter[T comparable, U any](config RouterConfig, authFunction func(conte
 
 	// Register routes from sub-routers
 	for _, sr := range config.SubRouters {
-		r.registerSubRouter(sr)
+		r.registerSubRouterWithResolvedOverrides(sr, common.RouteOverrides{})
 	}
 
 	return r
@@ -194,8 +194,8 @@ func NewRouter[T comparable, U any](config RouterConfig, authFunction func(conte
 // The sub-router's configuration is applied as follows:
 // - Path prefix is prepended to all routes in the sub-router
 // - Middlewares are added to (not replacing) global middlewares
-// - Configuration overrides (timeout, max body size, rate limit) apply only to direct routes
-// - Nested sub-routers will have their path prefixes concatenated but must set their own overrides
+// - Configuration overrides (timeout, max body size, rate limit, auth token) inherit into nested sub-routers by default
+// - Nested sub-routers can set IsolateOverrides to ignore parent sub-router overrides
 //
 // This is useful for conditionally adding routes or building routes programmatically.
 func (r *Router[T, U]) RegisterSubRouter(sr SubRouterConfig) {
@@ -204,9 +204,16 @@ func (r *Router[T, U]) RegisterSubRouter(sr SubRouterConfig) {
 
 // registerSubRouter registers all routes and nested sub-routers defined in a SubRouterConfig.
 // It applies the sub-router's path prefix, overrides, and middlewares.
-// For nested sub-routers, path prefixes are concatenated but configuration overrides are not inherited.
+// For nested sub-routers, path prefixes are concatenated and configuration overrides are inherited unless isolated.
 // Middlewares are combined additively: global + sub-router + route-specific.
 func (r *Router[T, U]) registerSubRouter(sr SubRouterConfig) {
+	r.registerSubRouterWithResolvedOverrides(sr, common.RouteOverrides{})
+}
+
+func (r *Router[T, U]) registerSubRouterWithResolvedOverrides(sr SubRouterConfig, parentOverrides common.RouteOverrides) {
+	resolvedOverrides := resolveSubRouterOverrides(parentOverrides, sr)
+	sr.Overrides = resolvedOverrides
+
 	// Register routes defined in this sub-router
 	for _, routeDefinition := range sr.Routes {
 		switch route := routeDefinition.(type) {
@@ -224,11 +231,12 @@ func (r *Router[T, U]) registerSubRouter(sr SubRouterConfig) {
 
 			maxBodySize := r.getEffectiveMaxBodySize(route.Overrides.MaxBodySize, sr.Overrides.MaxBodySize)
 			rateLimit := r.getEffectiveRateLimit(route.Overrides.RateLimit, sr.Overrides.RateLimit)
-			authTokenConfig := r.getEffectiveAuthTokenConfig(route.Overrides.AuthToken, sr.Overrides.AuthToken)
+			authTokenResolution := r.getEffectiveAuthTokenConfigWithOrigin(route.Overrides.AuthToken, sr.Overrides.AuthToken)
 			authLevel := route.AuthLevel // Use route-specific first
 			if authLevel == nil {
 				authLevel = sr.AuthLevel // Fallback to sub-router default
 			}
+			r.warnOnBuiltinAuthTokenFallback(fullPath, route.Methods, authLevel, authTokenResolution)
 
 			// Combine middlewares: sub-router + route-specific
 			allMiddlewares := make([]common.Middleware, 0, len(sr.Middlewares)+len(route.Middlewares))
@@ -236,7 +244,7 @@ func (r *Router[T, U]) registerSubRouter(sr SubRouterConfig) {
 			allMiddlewares = append(allMiddlewares, route.Middlewares...)
 
 			// Create a handler with all middlewares applied (global middlewares are added inside wrapHandler)
-			handler := r.wrapHandler(route.Handler, authLevel, authTokenConfig, timeout, maxBodySize, rateLimit, allMiddlewares)
+			handler := r.wrapHandler(route.Handler, authLevel, authTokenResolution.config, timeout, maxBodySize, rateLimit, allMiddlewares)
 
 			// Register the route with httprouter
 			for _, method := range route.Methods {
@@ -264,7 +272,7 @@ func (r *Router[T, U]) registerSubRouter(sr SubRouterConfig) {
 		nestedSRWithPrefix.PathPrefix = sr.PathPrefix + nestedSR.PathPrefix
 
 		// Register the nested sub-router
-		r.registerSubRouter(nestedSRWithPrefix)
+		r.registerSubRouterWithResolvedOverrides(nestedSRWithPrefix, resolvedOverrides)
 	}
 }
 
@@ -476,29 +484,63 @@ func (r *Router[T, U]) timeoutMiddleware(timeout time.Duration) common.Middlewar
 	}
 }
 
-// findSubRouterConfig recursively searches for a SubRouterConfig matching the target prefix.
-// Note: This performs an exact match on the prefix. More complex matching might be needed
-// if overlapping prefixes or inheritance are desired.
-func findSubRouterConfig(subRouters []SubRouterConfig, targetPrefix string) (*SubRouterConfig, bool) {
-	for i := range subRouters {
-		sr := &subRouters[i] // Use pointer for direct access
-		if sr.PathPrefix == targetPrefix {
-			return sr, true
+type subRouterConfigPrefixMatch struct {
+	config SubRouterConfig
+	found  bool
+	exact  bool
+}
+
+func resolveSubRouterConfigForPrefix(subRouters []SubRouterConfig, targetPrefix string, parentPrefix string, parentOverrides common.RouteOverrides) (SubRouterConfig, bool) {
+	match := resolveSubRouterConfigForPrefixMatch(subRouters, targetPrefix, parentPrefix, parentOverrides)
+	if !match.found {
+		return SubRouterConfig{}, false
+	}
+	return match.config, true
+}
+
+func resolveSubRouterConfigForPrefixMatch(subRouters []SubRouterConfig, targetPrefix string, parentPrefix string, parentOverrides common.RouteOverrides) subRouterConfigPrefixMatch {
+	var fallback SubRouterConfig
+	fallbackFound := false
+
+	for _, sr := range subRouters {
+		fullPathPrefix := parentPrefix + sr.PathPrefix
+		resolvedOverrides := resolveSubRouterOverrides(parentOverrides, sr)
+		resolvedSR := sr
+		resolvedSR.PathPrefix = fullPathPrefix
+		resolvedSR.Overrides = resolvedOverrides
+
+		if fullPathPrefix == targetPrefix {
+			return subRouterConfigPrefixMatch{config: resolvedSR, found: true, exact: true}
 		}
-		// Check nested sub-routers recursively
-		if foundSR, found := findSubRouterConfig(sr.SubRouters, targetPrefix); found {
-			return foundSR, true
+		if sr.PathPrefix == targetPrefix && !fallbackFound {
+			fallback = resolvedSR
+			fallbackFound = true
+		}
+		childMatch := resolveSubRouterConfigForPrefixMatch(sr.SubRouters, targetPrefix, fullPathPrefix, resolvedOverrides)
+		if childMatch.found {
+			if childMatch.exact {
+				return childMatch
+			}
+			if !fallbackFound {
+				fallback = childMatch.config
+				fallbackFound = true
+			}
 		}
 	}
-	return nil, false
+	if fallbackFound {
+		return subRouterConfigPrefixMatch{config: fallback, found: true}
+	}
+	return subRouterConfigPrefixMatch{}
 }
 
 // RegisterGenericRouteOnSubRouter registers a generic route on a specific sub-router after router creation.
 // This function is primarily used for dynamic route registration after the router has been initialized.
 // For static route configuration, prefer using NewGenericRouteDefinition within SubRouterConfig.Routes.
 //
-// The function locates the sub-router by path prefix, applies its configuration (middleware, timeouts,
-// rate limits), and registers the route with the combined settings.
+// The function locates the sub-router by resolved full path prefix, applies its configuration
+// (middleware, timeouts, rate limits), and registers the route with the combined settings.
+// Relative sub-router prefixes are still accepted as a compatibility fallback when no resolved
+// full path prefix matches.
 //
 // Type parameters:
 //   - Req: Request type for the route
@@ -516,7 +558,7 @@ func RegisterGenericRouteOnSubRouter[Req any, Resp any, UserID comparable, User 
 	route RouteConfig[Req, Resp],
 ) error {
 	// Find the sub-router config matching the prefix
-	sr, found := findSubRouterConfig(r.config.SubRouters, pathPrefix)
+	sr, found := resolveSubRouterConfigForPrefix(r.config.SubRouters, pathPrefix, "", common.RouteOverrides{})
 	if !found {
 		// Option 1: Return an error if prefix doesn't match any configured sub-router
 		return fmt.Errorf("no sub-router found with prefix: %s", pathPrefix)
@@ -530,18 +572,16 @@ func RegisterGenericRouteOnSubRouter[Req any, Resp any, UserID comparable, User 
 	var subRouterMaxBodySize int64
 	var subRouterRateLimit *common.RateLimitConfig[any, any] // Use common type here
 	var subRouterMiddlewares []common.Middleware
-	if sr != nil {
-		subRouterTimeout = sr.Overrides.Timeout
-		subRouterMaxBodySize = sr.Overrides.MaxBodySize
-		subRouterRateLimit = sr.Overrides.RateLimit // This is already common.RateLimitConfig[any, any]
-		subRouterMiddlewares = sr.Middlewares
-	}
+	subRouterTimeout = sr.Overrides.Timeout
+	subRouterMaxBodySize = sr.Overrides.MaxBodySize
+	subRouterRateLimit = sr.Overrides.RateLimit // This is already common.RateLimitConfig[any, any]
+	subRouterMiddlewares = sr.Middlewares
 
 	// Create a new route config instance to avoid modifying the original
 	finalRouteConfig := route
 
 	// Prefix the path
-	finalRouteConfig.Path = pathPrefix + route.Path
+	finalRouteConfig.Path = sr.PathPrefix + route.Path
 
 	// Combine middleware: global + sub-router + route-specific
 	allMiddlewares := make([]common.Middleware, 0, len(r.middlewares)+len(subRouterMiddlewares)+len(route.Middlewares))
@@ -554,11 +594,11 @@ func RegisterGenericRouteOnSubRouter[Req any, Resp any, UserID comparable, User 
 	effectiveTimeout := r.getEffectiveTimeout(route.Overrides.Timeout, subRouterTimeout)
 	effectiveMaxBodySize := r.getEffectiveMaxBodySize(route.Overrides.MaxBodySize, subRouterMaxBodySize)
 	effectiveRateLimit := r.getEffectiveRateLimit(route.Overrides.RateLimit, subRouterRateLimit) // This returns *common.RateLimitConfig[UserID, User]
-	effectiveAuthTokenConfig := r.getEffectiveAuthTokenConfig(route.Overrides.AuthToken, sr.Overrides.AuthToken)
-	finalRouteConfig.Overrides.AuthToken = &effectiveAuthTokenConfig
+	effectiveAuthTokenResolution := r.getEffectiveAuthTokenConfigWithOrigin(route.Overrides.AuthToken, sr.Overrides.AuthToken)
+	finalRouteConfig.Overrides.AuthToken = &effectiveAuthTokenResolution.config
 
 	// Call the underlying generic registration function with the modified config
-	RegisterGenericRoute(r, finalRouteConfig, effectiveTimeout, effectiveMaxBodySize, effectiveRateLimit)
+	registerGenericRouteWithAuthTokenResolution(r, finalRouteConfig, effectiveTimeout, effectiveMaxBodySize, effectiveRateLimit, effectiveAuthTokenResolution)
 
 	return nil
 }
@@ -929,7 +969,7 @@ func (r *Router[T, U]) Shutdown(ctx context.Context) error {
 // getEffectiveTimeout returns the effective timeout for a route.
 // Precedence order (first non-zero value wins):
 // 1. Route-specific timeout
-// 2. Sub-router timeout override (NOT inherited by nested sub-routers)
+// 2. Current or inherited sub-router timeout override
 // 3. Global timeout from RouterConfig
 func (r *Router[T, U]) getEffectiveTimeout(routeTimeout, subRouterTimeout time.Duration) time.Duration {
 	if routeTimeout > 0 {
@@ -941,11 +981,47 @@ func (r *Router[T, U]) getEffectiveTimeout(routeTimeout, subRouterTimeout time.D
 	return r.config.GlobalTimeout
 }
 
+func resolveSubRouterOverrides(parentOverrides common.RouteOverrides, sr SubRouterConfig) common.RouteOverrides {
+	resolved := parentOverrides
+	if sr.IsolateOverrides {
+		resolved = common.RouteOverrides{}
+	}
+
+	if sr.Overrides.Timeout > 0 {
+		resolved.Timeout = sr.Overrides.Timeout
+	}
+	if sr.Overrides.MaxBodySize > 0 {
+		resolved.MaxBodySize = sr.Overrides.MaxBodySize
+	}
+	if sr.Overrides.RateLimit != nil {
+		resolved.RateLimit = sr.Overrides.RateLimit
+	}
+	if sr.Overrides.AuthToken != nil {
+		resolved.AuthToken = sr.Overrides.AuthToken
+	}
+
+	return resolved
+}
+
 func defaultAuthTokenConfig() common.AuthTokenConfig {
 	return common.AuthTokenConfig{
 		Source:     common.AuthTokenSourceHeader,
 		HeaderName: defaultAuthHeaderName,
 	}
+}
+
+type authTokenConfigOrigin string
+
+const (
+	authTokenOriginRoute     authTokenConfigOrigin = "route"
+	authTokenOriginSubRouter authTokenConfigOrigin = "sub-router"
+	authTokenOriginGlobal    authTokenConfigOrigin = "global"
+	authTokenOriginDefault   authTokenConfigOrigin = "built-in default"
+)
+
+type authTokenConfigResolution struct {
+	config common.AuthTokenConfig
+	origin authTokenConfigOrigin
 }
 
 func normalizeAuthTokenConfig(config common.AuthTokenConfig) common.AuthTokenConfig {
@@ -959,6 +1035,27 @@ func (r *Router[T, U]) warnOnInvalidAuthTokenConfig(config common.AuthTokenConfi
 	if config.Source == common.AuthTokenSourceCookie && config.CookieName == "" {
 		r.logger.Warn("Auth token cookie name not configured")
 	}
+}
+
+func routeMethodStrings(methods []HttpMethod) []string {
+	methodStrings := make([]string, len(methods))
+	for i, method := range methods {
+		methodStrings[i] = string(method)
+	}
+	return methodStrings
+}
+
+func (r *Router[T, U]) warnOnBuiltinAuthTokenFallback(path string, methods []HttpMethod, authLevel *AuthLevel, resolution authTokenConfigResolution) {
+	if authLevel == nil || *authLevel != AuthRequired || resolution.origin != authTokenOriginDefault {
+		return
+	}
+
+	r.logger.Warn("Auth-required route using built-in default auth token source",
+		zap.String("path", path),
+		zap.Strings("methods", routeMethodStrings(methods)),
+		zap.String("auth_token_source", "header"),
+		zap.String("header_name", defaultAuthHeaderName),
+	)
 }
 
 func buildAuthTokenExtractor(config common.AuthTokenConfig) authTokenExtractor {
@@ -1004,22 +1101,42 @@ func buildAuthTokenExtractor(config common.AuthTokenConfig) authTokenExtractor {
 // getEffectiveAuthTokenConfig returns the effective auth token config for a route.
 // Precedence order (first non-nil value wins):
 // 1. Route-specific auth token config
-// 2. Sub-router auth token override (NOT inherited by nested sub-routers)
-// 3. Default header-based auth token config
+// 2. Sub-router auth token override
+// 3. Global auth token config from RouterConfig
+// 4. Default header-based auth token config
 func (r *Router[T, U]) getEffectiveAuthTokenConfig(routeAuth, subRouterAuth *common.AuthTokenConfig) common.AuthTokenConfig {
+	return r.getEffectiveAuthTokenConfigWithOrigin(routeAuth, subRouterAuth).config
+}
+
+func (r *Router[T, U]) getEffectiveAuthTokenConfigWithOrigin(routeAuth, subRouterAuth *common.AuthTokenConfig) authTokenConfigResolution {
 	if routeAuth != nil {
-		return normalizeAuthTokenConfig(*routeAuth)
+		return authTokenConfigResolution{
+			config: normalizeAuthTokenConfig(*routeAuth),
+			origin: authTokenOriginRoute,
+		}
 	}
 	if subRouterAuth != nil {
-		return normalizeAuthTokenConfig(*subRouterAuth)
+		return authTokenConfigResolution{
+			config: normalizeAuthTokenConfig(*subRouterAuth),
+			origin: authTokenOriginSubRouter,
+		}
 	}
-	return defaultAuthTokenConfig()
+	if r.config.GlobalAuthToken != nil {
+		return authTokenConfigResolution{
+			config: normalizeAuthTokenConfig(*r.config.GlobalAuthToken),
+			origin: authTokenOriginGlobal,
+		}
+	}
+	return authTokenConfigResolution{
+		config: defaultAuthTokenConfig(),
+		origin: authTokenOriginDefault,
+	}
 }
 
 // getEffectiveMaxBodySize returns the effective max body size for a route.
 // Precedence order (first non-zero value wins):
 // 1. Route-specific max body size
-// 2. Sub-router max body size override (NOT inherited by nested sub-routers)
+// 2. Current or inherited sub-router max body size override
 // 3. Global max body size from RouterConfig
 func (r *Router[T, U]) getEffectiveMaxBodySize(routeMaxBodySize, subRouterMaxBodySize int64) int64 {
 	if routeMaxBodySize > 0 {
@@ -1034,7 +1151,7 @@ func (r *Router[T, U]) getEffectiveMaxBodySize(routeMaxBodySize, subRouterMaxBod
 // getEffectiveRateLimit returns the effective rate limit for a route.
 // Precedence order (first non-nil value wins):
 // 1. Route-specific rate limit
-// 2. Sub-router rate limit override (NOT inherited by nested sub-routers)
+// 2. Current or inherited sub-router rate limit override
 // 3. Global rate limit from RouterConfig
 // The function also converts the generic type parameters from [any, any] to [T, U].
 func (r *Router[T, U]) getEffectiveRateLimit(routeRateLimit, subRouterRateLimit *common.RateLimitConfig[any, any]) *common.RateLimitConfig[T, U] { // Use common types
@@ -1311,7 +1428,7 @@ func (r *Router[T, U]) authenticateRequest(req *http.Request, extractToken authT
 // If authentication fails, it returns a 401 Unauthorized response.
 // It uses the middleware.AuthenticationWithUser function with a configurable authentication function.
 func (r *Router[T, U]) authRequiredMiddleware(next http.Handler) http.Handler {
-	return r.authRequiredMiddlewareWithConfig(defaultAuthTokenConfig())(next)
+	return r.authRequiredMiddlewareWithConfig(r.getEffectiveAuthTokenConfig(nil, nil))(next)
 }
 
 func (r *Router[T, U]) authRequiredMiddlewareWithConfig(authTokenConfig common.AuthTokenConfig) common.Middleware {
@@ -1347,7 +1464,7 @@ func (r *Router[T, U]) authRequiredMiddlewareWithConfig(authTokenConfig common.A
 // It tries to authenticate the request and adds the user ID to the context if successful,
 // but allows the request to proceed even if authentication fails.
 func (r *Router[T, U]) authOptionalMiddleware(next http.Handler) http.Handler {
-	return r.authOptionalMiddlewareWithConfig(defaultAuthTokenConfig())(next)
+	return r.authOptionalMiddlewareWithConfig(r.getEffectiveAuthTokenConfig(nil, nil))(next)
 }
 
 func (r *Router[T, U]) authOptionalMiddlewareWithConfig(authTokenConfig common.AuthTokenConfig) common.Middleware {

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -679,42 +679,163 @@ func TestShutdownStopsIDGenerator(t *testing.T) {
 
 // --- Tests for Refactored Generic SubRouter Registration ---
 
-// TestFindSubRouterConfig tests the helper function for finding sub-router configs
-func TestFindSubRouterConfig(t *testing.T) {
-	nestedSR := SubRouterConfig{PathPrefix: "/api/v1/users"}
-	v1SR := SubRouterConfig{PathPrefix: "/api/v1", SubRouters: []SubRouterConfig{nestedSR}}
+// TestResolveSubRouterConfigForPrefix tests lookup of sub-router configs with resolved prefixes and overrides.
+func TestResolveSubRouterConfigForPrefix(t *testing.T) {
+	assertFound := func(t *testing.T, subRouters []SubRouterConfig, targetPrefix string, expectedPrefix string) SubRouterConfig {
+		t.Helper()
+
+		foundSR, found := resolveSubRouterConfigForPrefix(subRouters, targetPrefix, "", common.RouteOverrides{})
+		if !found {
+			t.Fatalf("Expected to find sub-router with prefix %s", targetPrefix)
+		}
+		if foundSR.PathPrefix != expectedPrefix {
+			t.Fatalf("Expected resolved prefix %q for target %q, got %q", expectedPrefix, targetPrefix, foundSR.PathPrefix)
+		}
+		return foundSR
+	}
+
+	nestedSR := SubRouterConfig{PathPrefix: "/users"}
+	v1SR := SubRouterConfig{
+		PathPrefix: "/api/v1",
+		Overrides:  common.RouteOverrides{Timeout: 2 * time.Second},
+		SubRouters: []SubRouterConfig{nestedSR},
+	}
 	v2SR := SubRouterConfig{PathPrefix: "/api/v2"}
 	subRouters := []SubRouterConfig{v1SR, v2SR}
 
 	// Test finding top-level
-	foundSR, found := findSubRouterConfig(subRouters, "/api/v1")
-	if !found {
-		t.Errorf("Expected to find sub-router with prefix /api/v1")
-	}
-	if foundSR == nil || foundSR.PathPrefix != "/api/v1" {
-		t.Errorf("Found incorrect sub-router or nil for /api/v1")
-	}
+	assertFound(t, subRouters, "/api/v1", "/api/v1")
 
 	// Test finding nested
-	foundSR, found = findSubRouterConfig(subRouters, "/api/v1/users")
-	if !found {
-		t.Errorf("Expected to find nested sub-router with prefix /api/v1/users")
-	}
-	if foundSR == nil || foundSR.PathPrefix != "/api/v1/users" {
-		t.Errorf("Found incorrect sub-router or nil for /api/v1/users")
+	foundSR := assertFound(t, subRouters, "/api/v1/users", "/api/v1/users")
+	if foundSR.Overrides.Timeout != 2*time.Second {
+		t.Errorf("Expected nested sub-router to inherit timeout override")
 	}
 
 	// Test finding non-existent
-	_, found = findSubRouterConfig(subRouters, "/api/v3")
+	_, found := resolveSubRouterConfigForPrefix(subRouters, "/api/v3", "", common.RouteOverrides{})
 	if found {
 		t.Errorf("Did not expect to find sub-router with prefix /api/v3")
 	}
 
 	// Test finding non-existent nested
-	_, found = findSubRouterConfig(subRouters, "/api/v1/posts")
+	_, found = resolveSubRouterConfigForPrefix(subRouters, "/api/v1/posts", "", common.RouteOverrides{})
 	if found {
 		t.Errorf("Did not expect to find sub-router with prefix /api/v1/posts")
 	}
+
+	t.Run("full prefix wins over earlier nested relative prefix", func(t *testing.T) {
+		subRouters := []SubRouterConfig{
+			{
+				PathPrefix: "/api",
+				SubRouters: []SubRouterConfig{
+					{PathPrefix: "/v1", Overrides: common.RouteOverrides{Timeout: time.Second}},
+				},
+			},
+			{
+				PathPrefix: "/v1",
+				Overrides:  common.RouteOverrides{Timeout: 3 * time.Second},
+			},
+		}
+
+		foundSR := assertFound(t, subRouters, "/v1", "/v1")
+		if foundSR.Overrides.Timeout != 3*time.Second {
+			t.Errorf("Expected top-level full match timeout, got %s", foundSR.Overrides.Timeout)
+		}
+	})
+
+	t.Run("relative prefix fallback remains supported", func(t *testing.T) {
+		subRouters := []SubRouterConfig{
+			{
+				PathPrefix: "/api",
+				Overrides:  common.RouteOverrides{Timeout: 7 * time.Second},
+				SubRouters: []SubRouterConfig{{PathPrefix: "/v1"}},
+			},
+		}
+
+		foundSR := assertFound(t, subRouters, "/v1", "/api/v1")
+		if foundSR.Overrides.Timeout != 7*time.Second {
+			t.Errorf("Expected fallback match to inherit parent timeout, got %s", foundSR.Overrides.Timeout)
+		}
+	})
+
+	t.Run("later nested full prefix beats earlier relative fallback", func(t *testing.T) {
+		subRouters := []SubRouterConfig{
+			{
+				PathPrefix: "/api",
+				SubRouters: []SubRouterConfig{
+					{PathPrefix: "/public/v1", Overrides: common.RouteOverrides{Timeout: time.Second}},
+				},
+			},
+			{
+				PathPrefix: "/public",
+				SubRouters: []SubRouterConfig{
+					{PathPrefix: "/v1", Overrides: common.RouteOverrides{Timeout: 4 * time.Second}},
+				},
+			},
+		}
+
+		foundSR := assertFound(t, subRouters, "/public/v1", "/public/v1")
+		if foundSR.Overrides.Timeout != 4*time.Second {
+			t.Errorf("Expected later full match timeout, got %s", foundSR.Overrides.Timeout)
+		}
+	})
+
+	t.Run("deep full prefix resolves deepest config", func(t *testing.T) {
+		subRouters := []SubRouterConfig{
+			{
+				PathPrefix: "/api",
+				SubRouters: []SubRouterConfig{
+					{
+						PathPrefix: "/v1",
+						SubRouters: []SubRouterConfig{
+							{
+								PathPrefix: "/users",
+								SubRouters: []SubRouterConfig{
+									{
+										PathPrefix: "/admin",
+										Overrides:  common.RouteOverrides{MaxBodySize: 128},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		foundSR := assertFound(t, subRouters, "/api/v1/users/admin", "/api/v1/users/admin")
+		if foundSR.Overrides.MaxBodySize != 128 {
+			t.Errorf("Expected deepest max body size override, got %d", foundSR.Overrides.MaxBodySize)
+		}
+	})
+
+	t.Run("exact full prefix respects isolated overrides", func(t *testing.T) {
+		subRouters := []SubRouterConfig{
+			{
+				PathPrefix: "/api",
+				Overrides: common.RouteOverrides{
+					Timeout:     5 * time.Second,
+					MaxBodySize: 64,
+				},
+				SubRouters: []SubRouterConfig{
+					{
+						PathPrefix:       "/v1",
+						IsolateOverrides: true,
+						Overrides:        common.RouteOverrides{MaxBodySize: 256},
+					},
+				},
+			},
+		}
+
+		foundSR := assertFound(t, subRouters, "/api/v1", "/api/v1")
+		if foundSR.Overrides.Timeout != 0 {
+			t.Errorf("Expected isolated sub-router not to inherit timeout, got %s", foundSR.Overrides.Timeout)
+		}
+		if foundSR.Overrides.MaxBodySize != 256 {
+			t.Errorf("Expected isolated sub-router max body size override, got %d", foundSR.Overrides.MaxBodySize)
+		}
+	})
 }
 
 // TestRegisterGenericRouteOnSubRouter tests the functional registration method
@@ -729,7 +850,7 @@ func TestRegisterGenericRouteOnSubRouter(t *testing.T) {
 	}
 
 	// Define sub-routers first
-	usersV1SR := SubRouterConfig{PathPrefix: "/api/v1/users"}
+	usersV1SR := SubRouterConfig{PathPrefix: "/users"}
 	apiV1SR := SubRouterConfig{PathPrefix: "/api/v1", SubRouters: []SubRouterConfig{usersV1SR}}
 
 	// Create router with sub-router structure
@@ -780,6 +901,62 @@ func TestRegisterGenericRouteOnSubRouter(t *testing.T) {
 	err = RegisterGenericRouteOnSubRouter(r, "/api/v2", routeCfg)
 	if err == nil {
 		t.Errorf("Expected an error when registering on non-existent prefix, but got nil")
+	}
+}
+
+func TestRegisterGenericRouteOnSubRouterRelativeNestedPrefixUsesResolvedPath(t *testing.T) {
+	logger := zap.NewNop()
+	authFunc := func(ctx context.Context, token string) (*string, bool) { user := "user"; return &user, true }
+	userIDFunc := func(user *string) string {
+		if user == nil {
+			return ""
+		}
+		return *user
+	}
+
+	r := NewRouter(RouterConfig{
+		Logger: logger,
+		SubRouters: []SubRouterConfig{
+			{
+				PathPrefix: "/api",
+				SubRouters: []SubRouterConfig{
+					{PathPrefix: "/v1"},
+				},
+			},
+		},
+	}, authFunc, userIDFunc)
+
+	routeCfg := RouteConfig[TestRequest, TestResponse]{
+		Path:    "/info",
+		Methods: []HttpMethod{MethodPost},
+		Codec:   codec.NewJSONCodec[TestRequest, TestResponse](),
+		Handler: func(req *http.Request, data TestRequest) (TestResponse, error) {
+			return TestResponse{Greeting: "Info for " + data.Name, Age: data.Age}, nil
+		},
+	}
+
+	err := RegisterGenericRouteOnSubRouter(r, "/v1", routeCfg)
+	if err != nil {
+		t.Fatalf("RegisterGenericRouteOnSubRouter failed: %v", err)
+	}
+
+	reqBody := `{"name":"Relative","age":42}`
+	req := httptest.NewRequest("POST", "/api/v1/info", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("Expected status OK (200) for resolved full path, got %d", rr.Code)
+	}
+
+	req = httptest.NewRequest("POST", "/v1/info", strings.NewReader(reqBody))
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("Expected raw relative path to remain unregistered, got %d", rr.Code)
 	}
 }
 

--- a/pkg/router/router_test.go
+++ b/pkg/router/router_test.go
@@ -1864,7 +1864,7 @@ func TestAuthRequiredMiddleware_OptionsRequireAuth(t *testing.T) {
 	})
 
 	// Apply the middleware directly for testing its behavior
-	wrappedHandler := r.authRequiredMiddleware(handler)
+	wrappedHandler := r.authRequiredMiddlewareWithConfig(defaultAuthTokenConfig())(handler)
 	server := httptest.NewServer(wrappedHandler)
 	defer server.Close()
 
@@ -1962,7 +1962,7 @@ func TestAuthOptionalMiddleware_OptionsBypass(t *testing.T) {
 	})
 
 	// Apply the middleware directly
-	wrappedHandler := r.authOptionalMiddleware(handler)
+	wrappedHandler := r.authOptionalMiddlewareWithConfig(defaultAuthTokenConfig())(handler)
 	server := httptest.NewServer(wrappedHandler)
 	defer server.Close()
 


### PR DESCRIPTION
Nested sub-routers now inherit their parent sub-router's configuration
  overrides (timeout, max body size, rate limit, and auth token source)
  by default. Previously these were not inherited and each nested level
  had to redeclare them. Set SubRouterConfig.IsolateOverrides to opt a
  sub-router (and its descendants) out of parent inheritance; RouterConfig
  globals still apply.

  Also:
  - Add RouterConfig.GlobalAuthToken for an application-wide default auth
    token source. Effective precedence is now: route override, current or
    inherited sub-router override, global config, then the built-in
    Authorization header default.
  - Log a registration-time warning when an AuthRequired route resolves to
    the built-in default token source because no route, sub-router, or
    global source is configured.
  - Resolve sub-router lookups by full path prefix so dynamic registration
    via RegisterGenericRouteOnSubRouter on a nested sub-router produces the
    correct concatenated path (relative-prefix lookup retained as a
    fallback).
  - Update README and docs for the new precedence and inheritance rules.

  BREAKING CHANGE: Sub-router configuration overrides (timeout, max body
  size, rate limit, auth token source) are now inherited by nested
  sub-routers by default. Routes in nested sub-routers that previously fell
  through to RouterConfig globals will now pick up the parent sub-router's
  overrides. This can change effective timeouts, rate limits, body-size
  limits, and—most importantly—the auth token source used for AuthRequired
  routes. Audit nested sub-routers and set IsolateOverrides: true where the
  previous (non-inherited) behavior is required.