### PR TITLE
Optimize hot path allocations and context handling

### DIFF
--- a/pkg/middleware/ratelimit.go
+++ b/pkg/middleware/ratelimit.go
@@ -95,7 +95,9 @@ func (l *slidingWindowLimiter) allow(limit int, window time.Duration, now time.T
 // The composite key includes limit and window so different rate limits for the
 // same base key don't share counters.
 func (u *UberRateLimiter) getLimiter(key string, limit int, window time.Duration) *slidingWindowLimiter {
-	compositeKey := fmt.Sprintf("%s|%d|%d", key, limit, int64(window))
+	// Built with strconv instead of fmt.Sprintf: this runs on every
+	// rate-limited request and Sprintf's reflection is measurably slower.
+	compositeKey := key + "|" + strconv.Itoa(limit) + "|" + strconv.FormatInt(int64(window), 10)
 
 	// Fast path: Check if limiter already exists.
 	if limiter, ok := u.limiters.Load(compositeKey); ok {

--- a/pkg/middleware/trace.go
+++ b/pkg/middleware/trace.go
@@ -153,6 +153,12 @@ func CreateTraceMiddleware[T comparable, U any](generator *IDGenerator) common.M
 				traceID = generator.GetIDNonBlocking()
 			}
 
+			// When an SRouterContext already exists (always the case inside the
+			// router, which installs it before dispatch), WithTraceID mutates it
+			// in place and returns the same context, so cloning the request is
+			// unnecessary.
+			_, hadSRouterCtx := scontext.GetSRouterContext[T, U](r.Context())
+
 			// Add the trace ID to the request context using the correct generic types
 			ctx := scontext.WithTraceID[T, U](r.Context(), traceID) // Use scontext with router's T and U
 
@@ -160,7 +166,10 @@ func CreateTraceMiddleware[T comparable, U any](generator *IDGenerator) common.M
 			w.Header().Set("X-Trace-ID", traceID)
 
 			// Call the next handler with the request containing the updated context
-			next.ServeHTTP(w, r.WithContext(ctx))
+			if !hadSRouterCtx {
+				r = r.WithContext(ctx)
+			}
+			next.ServeHTTP(w, r)
 		})
 	}
 }

--- a/pkg/router/benchmark_test.go
+++ b/pkg/router/benchmark_test.go
@@ -382,3 +382,36 @@ func BenchmarkMemoryUsage(b *testing.B) {
 	// b.Logf("Final Sys = %v MiB", bToMb(mEnd.Sys))
 	// b.Logf("GC Runs = %v", mEnd.NumGC - mStart.NumGC)
 }
+
+// BenchmarkInstrumentedAuthRoute measures the fully-instrumented hot path:
+// trace ID injection, request summary logging (status/bytes capture via the
+// pooled metrics writer), required authentication, and X-Forwarded-For client
+// IP extraction. A no-op logger is used so the benchmark measures router
+// overhead rather than log encoding.
+func BenchmarkInstrumentedAuthRoute(b *testing.B) {
+	authLevel := AuthRequired
+	r := NewRouter(RouterConfig{
+		Logger:            zap.NewNop(),
+		TraceIDBufferSize: 1000,
+		IPConfig:          DefaultIPConfig(),
+	}, nopAuthFunc, userIDFromString)
+	r.RegisterRoute(RouteConfigBase{
+		Path:      "/secure",
+		Methods:   []HttpMethod{MethodGet},
+		AuthLevel: &authLevel,
+		Handler:   simpleHandler,
+	})
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			req, _ := http.NewRequest(http.MethodGet, "/secure", nil)
+			req.Header.Set("Authorization", "Bearer token")
+			req.Header.Set("X-Forwarded-For", "203.0.113.7, 10.0.0.1")
+			req.RemoteAddr = "10.0.0.1:1234"
+			rr := httptest.NewRecorder()
+			r.ServeHTTP(rr, req)
+		}
+	})
+}

--- a/pkg/router/ip.go
+++ b/pkg/router/ip.go
@@ -66,11 +66,19 @@ func ClientIPMiddleware[T comparable, U any](config *IPConfig) func(http.Handler
 			// Extract the client IP based on the configuration
 			clientIP := extractClientIP(r, config)
 
+			// When an SRouterContext already exists, WithClientIP mutates it in
+			// place and returns the same context, so cloning the request is
+			// unnecessary.
+			_, hadSRouterCtx := scontext.GetSRouterContext[T, U](r.Context())
+
 			// Add the client IP to the SRouterContext
 			ctx := scontext.WithClientIP[T, U](r.Context(), clientIP) // Use scontext
 
 			// Call the next handler with the updated context
-			next.ServeHTTP(w, r.WithContext(ctx))
+			if !hadSRouterCtx {
+				r = r.WithContext(ctx)
+			}
+			next.ServeHTTP(w, r)
 		})
 	}
 }
@@ -117,14 +125,17 @@ func extractIPFromXForwardedFor(r *http.Request) string {
 	}
 
 	// Use the rightmost (most recently appended, least spoofable) entry.
-	ips := strings.Split(xff, ",")
-	for i := len(ips) - 1; i >= 0; i-- {
-		if ip := strings.TrimSpace(ips[i]); ip != "" {
+	// Scan from the end without splitting so no intermediate slice is allocated.
+	for {
+		comma := strings.LastIndexByte(xff, ',')
+		if ip := strings.TrimSpace(xff[comma+1:]); ip != "" {
 			return ip
 		}
+		if comma < 0 {
+			return ""
+		}
+		xff = xff[:comma]
 	}
-
-	return ""
 }
 
 // cleanIP removes the port from an IP address if present

--- a/pkg/router/metrics_test.go
+++ b/pkg/router/metrics_test.go
@@ -193,7 +193,7 @@ func TestMetricsResponseWriterFlush(t *testing.T) {
 
 	// Create a metrics response writer with string as both the user ID and user type
 	mrw := &metricsResponseWriter[string, string]{
-		baseResponseWriter: &baseResponseWriter{ResponseWriter: rr},
+		baseResponseWriter: baseResponseWriter{ResponseWriter: rr},
 		statusCode:         http.StatusOK,
 	}
 
@@ -270,7 +270,7 @@ func TestMetricsResponseWriter(t *testing.T) {
 
 	// Create a metrics response writer with string as both the user ID and user type
 	mrw := &metricsResponseWriter[string, string]{
-		baseResponseWriter: &baseResponseWriter{ResponseWriter: rr},
+		baseResponseWriter: baseResponseWriter{ResponseWriter: rr},
 		statusCode:         http.StatusOK,
 	}
 

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -687,7 +687,7 @@ func (r *Router[T, U]) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		mrw := r.metricsWriterPool.Get().(*metricsResponseWriter[T, U])
 
 		// Initialize the writer with the current request data
-		mrw.baseResponseWriter = &baseResponseWriter{ResponseWriter: w}
+		mrw.baseResponseWriter = baseResponseWriter{ResponseWriter: w}
 		mrw.statusCode = http.StatusOK
 		mrw.startTime = time.Now()
 		mrw.request = req
@@ -703,8 +703,13 @@ func (r *Router[T, U]) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			ip, _ := scontext.GetClientIPFromRequest[T, U](req)
 			ua, _ := scontext.GetUserAgentFromRequest[T, U](req)
 
-			// 2) Build unified fields - the UNION of all previously separate log fields
-			fields := append(r.baseFields(req),
+			// 2) Build unified fields - the UNION of all previously separate log
+			// fields. Sized for all fields (including the optional trace ID) up
+			// front so this per-request path allocates the slice exactly once.
+			fields := make([]zap.Field, 0, 8)
+			fields = append(fields,
+				zap.String("method", req.Method),
+				zap.String("path", req.URL.Path),
 				zap.Int("status", mrw.statusCode),
 				zap.Duration("duration", duration),
 				zap.Int64("bytes", mrw.bytesWritten),
@@ -730,7 +735,7 @@ func (r *Router[T, U]) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			r.logger.Log(lvl, "Request summary statistics", fields...)
 
 			// Reset fields that might hold references to prevent memory leaks
-			mrw.baseResponseWriter = nil
+			mrw.baseResponseWriter = baseResponseWriter{}
 			mrw.request = nil
 			mrw.router = nil
 
@@ -782,9 +787,8 @@ func (r *Router[T, U]) handleCORS(w http.ResponseWriter, req *http.Request) (*ht
 			// For actual requests, we *could* block here, but it's often better to let the request proceed
 			// and let the browser enforce the lack of Allow-Origin header.
 			// However, we MUST NOT set the Allow-Origin header.
-			// We also need to store the *lack* of allowance in the context.
-			ctx = scontext.WithCORSInfo[T, U](ctx, "", false) // Store empty origin, false credentials
-			req = req.WithContext(ctx)
+			// The *lack* of allowance is stored in the context by the
+			// unconditional WithCORSInfo call below (correctAllowOrigin stays "").
 			// The response still varies by Origin (an allowed origin would get
 			// CORS headers), so set Vary to keep shared caches correct.
 			w.Header().Add("Vary", "Origin")
@@ -967,8 +971,10 @@ func (bw *baseResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 
 // metricsResponseWriter is a wrapper around http.ResponseWriter that captures metrics.
 // It tracks the status code, bytes written, and timing information for each response.
+// baseResponseWriter is embedded by value so pooled writers are reinitialized
+// without allocating a fresh wrapper per request.
 type metricsResponseWriter[T comparable, U any] struct {
-	*baseResponseWriter
+	baseResponseWriter
 	statusCode   int
 	bytesWritten int64
 	startTime    time.Time
@@ -1521,14 +1527,19 @@ func (r *Router[T, U]) authenticateRequest(req *http.Request, extractToken authT
 
 	if user, valid := r.authFunction(req.Context(), token); valid {
 		id := r.getUserIdFromUser(user)
+		// When an SRouterContext already exists (always the case for requests
+		// routed through ServeHTTP, which installs it before dispatch), the
+		// With* helpers mutate it in place and return the same context. Any
+		// trace ID already on that shared context is preserved automatically,
+		// and cloning the request is only needed when a context was created.
+		_, hadSRouterCtx := scontext.GetSRouterContext[T, U](req.Context())
 		ctx := scontext.WithUserID[T, U](req.Context(), id)
 		if r.config.AddUserObjectToCtx {
 			ctx = scontext.WithUser[T](ctx, user)
 		}
-		if traceID := scontext.GetTraceIDFromRequest[T, U](req); traceID != "" {
-			ctx = scontext.WithTraceID[T, U](ctx, traceID)
+		if !hadSRouterCtx {
+			req = req.WithContext(ctx)
 		}
-		req = req.WithContext(ctx)
 		return req, true, ""
 	}
 	return req, false, "invalid token"

--- a/pkg/scontext/context.go
+++ b/pkg/scontext/context.go
@@ -85,13 +85,12 @@ type SRouterContext[T comparable, U any] struct {
 	Flags map[string]bool
 }
 
-// NewSRouterContext creates a new SRouterContext instance with initialized fields.
-// It returns a pointer to a new context with an empty Flags map ready for use.
+// NewSRouterContext creates a new SRouterContext instance.
+// The Flags map is allocated lazily by WithFlag on first use, so contexts on
+// requests that never set a flag (the common case) avoid the map allocation.
 // T is the User ID type (comparable), U is the User object type (any).
 func NewSRouterContext[T comparable, U any]() *SRouterContext[T, U] {
-	return &SRouterContext[T, U]{
-		Flags: make(map[string]bool),
-	}
+	return &SRouterContext[T, U]{}
 }
 
 // GetSRouterContext retrieves the SRouterContext from a standard context.Context.


### PR DESCRIPTION
## Summary
This PR optimizes the request handling hot path by reducing allocations and improving context mutation efficiency. Changes focus on eliminating unnecessary pointer indirections, avoiding redundant request cloning, and optimizing string parsing in rate limiting.

## Key Changes

### Memory Allocation Optimizations
- **Embed baseResponseWriter by value** in metricsResponseWriter instead of pointer, eliminating one allocation per pooled writer initialization
- **Pre-allocate zap.Field slice** with exact capacity (8 fields) in ServeHTTP logging path to avoid slice growth allocations
- **Lazy-initialize Flags map** in SRouterContext—only allocate when WithFlag is called, avoiding unnecessary map allocations for requests that never set flags

### Context Mutation Efficiency
- **Avoid redundant request cloning** in middleware and authentication when SRouterContext already exists (the common case inside ServeHTTP)
  - ClientIPMiddleware, CreateTraceMiddleware, and authenticateRequest now check for existing SRouterContext and skip req.WithContext() when the context is already being mutated in place
  - This optimization is safe because the With* helpers in scontext mutate the existing context in place when one is present
- **Simplify CORS context handling** by removing redundant context assignment and clarifying the unconditional WithCORSInfo call

### Rate Limiting Performance
- **Replace fmt.Sprintf with string concatenation and strconv** in UberRateLimiter.getLimiter() to avoid reflection overhead on every rate-limited request

### Testing
- **Add BenchmarkInstrumentedAuthRoute** to measure the fully-instrumented hot path including trace ID injection, request logging, authentication, and X-Forwarded-For extraction with a no-op logger

### Code Quality
- **Optimize X-Forwarded-For parsing** to scan from the end without allocating an intermediate slice
- **Update comments** to clarify context mutation behavior and allocation strategies
- **Fix test setup** to use embedded baseResponseWriter by value instead of pointer

## Implementation Details
The context mutation optimization is particularly important: when ServeHTTP creates an SRouterContext before dispatching to middleware, subsequent With* calls (WithTraceID, WithClientIP, WithUserID) mutate that context in place and return the same context object. By checking for the presence of an existing SRouterContext, we can skip the expensive req.WithContext() call that would otherwise clone the request. This is safe because the context is already shared and being mutated in place.

https://claude.ai/code/session_01T2Vm5Rr6NbsHdxzRzVeL76