### PR TITLE
Add comprehensive test coverage for router, middleware, and context packages

### DIFF
--- a/pkg/metrics/handler_method_test.go
+++ b/pkg/metrics/handler_method_test.go
@@ -1,0 +1,139 @@
+package metrics
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// TestHandlerAppliesDefaultTags verifies that DefaultTags from the middleware
+// config are applied to every metric the Handler emits, that tags with empty
+// values are skipped, and that route/status tags are still added on top.
+func TestHandlerAppliesDefaultTags(t *testing.T) {
+	registry := NewMockMetricsRegistry()
+	middleware := NewMetricsMiddleware[string, any](registry, MetricsMiddlewareConfig{
+		EnableLatency:    true,
+		EnableThroughput: true,
+		EnableQPS:        true,
+		EnableErrors:     true,
+		DefaultTags: Tags{
+			"service": "api",
+			"region":  "", // Empty values must not be emitted as tags.
+		},
+	})
+
+	handler := middleware.Handler("fallback", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	req, err := http.NewRequest("POST", "/missing", strings.NewReader("payload"))
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+	handler.ServeHTTP(NewMockResponseWriter(), req)
+
+	checkTags := func(name string, tags Tags, extra Tags) {
+		t.Helper()
+		if tags["service"] != "api" {
+			t.Errorf("%s: expected default tag service=api, got tags %v", name, tags)
+		}
+		if _, present := tags["region"]; present {
+			t.Errorf("%s: empty-valued default tag %q must not be emitted, got tags %v", name, "region", tags)
+		}
+		for k, v := range extra {
+			if tags[k] != v {
+				t.Errorf("%s: expected tag %s=%s, got tags %v", name, k, v, tags)
+			}
+		}
+	}
+
+	latency, ok := registry.histograms["request_latency_seconds"].(*MockHistogram)
+	if !ok {
+		t.Fatal("expected request_latency_seconds histogram to be built")
+	}
+	checkTags("request_latency_seconds", latency.Tags(), Tags{"route": "fallback"})
+
+	allLatency, ok := registry.histograms["all_request_latency_seconds"].(*MockHistogram)
+	if !ok {
+		t.Fatal("expected all_request_latency_seconds histogram to be built")
+	}
+	checkTags("all_request_latency_seconds", allLatency.Tags(), nil)
+
+	qps, ok := registry.counters["requests_total"].(*MockCounter)
+	if !ok {
+		t.Fatal("expected requests_total counter to be built")
+	}
+	checkTags("requests_total", qps.Tags(), Tags{"route": "fallback"})
+
+	throughput, ok := registry.counters["request_throughput_bytes"].(*MockCounter)
+	if !ok {
+		t.Fatal("expected request_throughput_bytes counter to be built")
+	}
+	checkTags("request_throughput_bytes", throughput.Tags(), Tags{"route": "fallback"})
+
+	errors, ok := registry.counters["request_errors_total"].(*MockCounter)
+	if !ok {
+		t.Fatal("expected request_errors_total counter to be built")
+	}
+	checkTags("request_errors_total", errors.Tags(), Tags{"route": "fallback", "status_code": "404"})
+}
+
+// TestHandlerReusesCachedMetrics verifies that the per-route metric instances
+// are built once and reused across requests: repeated requests must accumulate
+// into the same counter/histogram rather than rebuilding fresh metrics.
+func TestHandlerReusesCachedMetrics(t *testing.T) {
+	registry := NewMockMetricsRegistry()
+	middleware := NewMetricsMiddleware[string, any](registry, MetricsMiddlewareConfig{
+		EnableLatency:    true,
+		EnableThroughput: true,
+		EnableQPS:        true,
+	})
+
+	handler := middleware.Handler("cached-route", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	const requests = 3
+	const bodySize = 7 // len("payload")
+	for range requests {
+		req, err := http.NewRequest("POST", "/cached", strings.NewReader("payload"))
+		if err != nil {
+			t.Fatalf("Failed to create request: %v", err)
+		}
+		handler.ServeHTTP(NewMockResponseWriter(), req)
+	}
+
+	// If caching failed, each request would build (and overwrite) a fresh
+	// counter holding only that request's increment.
+	qps, ok := registry.counters["requests_total"].(*MockCounter)
+	if !ok {
+		t.Fatal("expected requests_total counter to be built")
+	}
+	if qps.Value() != requests {
+		t.Errorf("expected requests_total to accumulate %d increments on one instance, got %v", requests, qps.Value())
+	}
+
+	totalQPS, ok := registry.counters["all_requests_total"].(*MockCounter)
+	if !ok {
+		t.Fatal("expected all_requests_total counter to be built")
+	}
+	if totalQPS.Value() != requests {
+		t.Errorf("expected all_requests_total to accumulate %d increments on one instance, got %v", requests, totalQPS.Value())
+	}
+
+	throughput, ok := registry.counters["request_throughput_bytes"].(*MockCounter)
+	if !ok {
+		t.Fatal("expected request_throughput_bytes counter to be built")
+	}
+	if throughput.Value() != requests*bodySize {
+		t.Errorf("expected request_throughput_bytes to accumulate %d bytes on one instance, got %v", requests*bodySize, throughput.Value())
+	}
+
+	latency, ok := registry.histograms["request_latency_seconds"].(*MockHistogram)
+	if !ok {
+		t.Fatal("expected request_latency_seconds histogram to be built")
+	}
+	if len(latency.observations) != requests {
+		t.Errorf("expected %d latency observations on one histogram instance, got %d", requests, len(latency.observations))
+	}
+}

--- a/pkg/middleware/ratelimit_slidingwindow_test.go
+++ b/pkg/middleware/ratelimit_slidingwindow_test.go
@@ -1,0 +1,97 @@
+package middleware
+
+import (
+	"testing"
+	"time"
+)
+
+// TestSlidingWindowRolloverWeightsPreviousWindow verifies the window rollover
+// behavior of the sliding-window limiter: the previous window's count keeps
+// counting against the limit in proportion to how much it still overlaps the
+// sliding window, smoothing bursts at window boundaries.
+func TestSlidingWindowRolloverWeightsPreviousWindow(t *testing.T) {
+	l := &slidingWindowLimiter{}
+	const limit = 2
+	window := time.Minute
+	t0 := time.Unix(1_000_000, 0)
+
+	// Use up the full limit inside the first window.
+	if allowed, remaining, _ := l.allow(limit, window, t0); !allowed || remaining != 1 {
+		t.Fatalf("first request: got (allowed=%v, remaining=%d), want (true, 1)", allowed, remaining)
+	}
+	if allowed, remaining, _ := l.allow(limit, window, t0.Add(time.Second)); !allowed || remaining != 0 {
+		t.Fatalf("second request: got (allowed=%v, remaining=%d), want (true, 0)", allowed, remaining)
+	}
+
+	// Over the limit: denied, and reset reports the time left in the window.
+	allowed, _, reset := l.allow(limit, window, t0.Add(10*time.Second))
+	if allowed {
+		t.Fatal("third request inside the window should be denied")
+	}
+	if reset != 50*time.Second {
+		t.Errorf("expected reset of 50s (window remainder), got %v", reset)
+	}
+
+	// Exactly at the window boundary the previous window still fully overlaps
+	// the sliding window, so a burst right at the boundary is still denied.
+	allowed, _, reset = l.allow(limit, window, t0.Add(window))
+	if allowed {
+		t.Fatal("request at the window boundary should still be denied (previous window fully weighted)")
+	}
+	if reset != window {
+		t.Errorf("expected reset of one full window, got %v", reset)
+	}
+
+	// Halfway through the second window only half of the previous window's
+	// 2 requests count (estimated usage 1 of 2), so one request is allowed.
+	if allowed, remaining, _ := l.allow(limit, window, t0.Add(90*time.Second)); !allowed || remaining != 0 {
+		t.Fatalf("mid-second-window request: got (allowed=%v, remaining=%d), want (true, 0)", allowed, remaining)
+	}
+
+	// After a gap of two or more full windows all history is discarded and the
+	// full limit is available again.
+	if allowed, remaining, _ := l.allow(limit, window, t0.Add(4*window)); !allowed || remaining != 1 {
+		t.Fatalf("request after long idle gap: got (allowed=%v, remaining=%d), want (true, 1)", allowed, remaining)
+	}
+}
+
+// TestUberRateLimiterAllowNonPositiveLimit verifies that a zero or negative
+// limit denies every request immediately and reports the window as the reset.
+func TestUberRateLimiterAllowNonPositiveLimit(t *testing.T) {
+	limiter := NewUberRateLimiter()
+
+	for _, limit := range []int{0, -1} {
+		allowed, remaining, reset := limiter.Allow("nonpositive", limit, time.Minute)
+		if allowed {
+			t.Errorf("limit %d: request should be denied", limit)
+		}
+		if remaining != 0 {
+			t.Errorf("limit %d: expected 0 remaining, got %d", limit, remaining)
+		}
+		if reset != time.Minute {
+			t.Errorf("limit %d: expected reset equal to window, got %v", limit, reset)
+		}
+	}
+}
+
+// TestUberRateLimiterAllowNonPositiveWindowDefaultsToOneSecond verifies that a
+// zero (or negative) window falls back to a one-second window instead of
+// producing a degenerate limiter.
+func TestUberRateLimiterAllowNonPositiveWindowDefaultsToOneSecond(t *testing.T) {
+	limiter := NewUberRateLimiter()
+
+	allowed, remaining, _ := limiter.Allow("zero-window", 1, 0)
+	if !allowed || remaining != 0 {
+		t.Fatalf("first request: got (allowed=%v, remaining=%d), want (true, 0)", allowed, remaining)
+	}
+
+	// The second request must be denied, and the reset must reflect the
+	// defaulted one-second window.
+	allowed, _, reset := limiter.Allow("zero-window", 1, 0)
+	if allowed {
+		t.Fatal("second request should be denied within the defaulted window")
+	}
+	if reset <= 0 || reset > time.Second {
+		t.Errorf("expected reset within (0, 1s] for the defaulted window, got %v", reset)
+	}
+}

--- a/pkg/middleware/timeout_writer_test.go
+++ b/pkg/middleware/timeout_writer_test.go
@@ -1,0 +1,106 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestTimeoutDoesNotOverwriteStartedResponse verifies that when the handler
+// has already started writing a response before the timeout fires, the
+// middleware does not write a 408 on top of it: the client receives the
+// handler's partial response untouched.
+func TestTimeoutDoesNotOverwriteStartedResponse(t *testing.T) {
+	wrote := make(chan struct{})
+	release := make(chan struct{})
+	handlerDone := make(chan struct{})
+
+	handler := timeout(30 * time.Millisecond)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer close(handlerDone)
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte("partial"))
+		close(wrote)
+		<-release // Keep running past the timeout.
+	}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest("GET", "/", nil))
+
+	// The middleware returned at the timeout. Synchronize with the handler's
+	// write, after which it stays blocked, so the recorder is safe to inspect.
+	<-wrote
+	if rec.Code != http.StatusAccepted {
+		t.Errorf("status = %d, want %d (handler's status must not be replaced by a timeout response)", rec.Code, http.StatusAccepted)
+	}
+	if got := rec.Body.String(); got != "partial" {
+		t.Errorf("body = %q, want %q (no timeout error may be appended)", got, "partial")
+	}
+
+	close(release)
+	<-handlerDone
+}
+
+// TestMutexResponseWriterRejectsAllWritesAfterTimeout verifies that once the
+// timeout has fired, a late handler can no longer touch the underlying
+// response writer: WriteHeader is dropped, Write fails with
+// http.ErrHandlerTimeout, and Flush is a no-op.
+func TestMutexResponseWriterRejectsAllWritesAfterTimeout(t *testing.T) {
+	rec := httptest.NewRecorder()
+	var mu sync.Mutex
+	rw := &mutexResponseWriter{ResponseWriter: rec, mu: &mu}
+	rw.timedOut.Store(true)
+
+	rw.WriteHeader(http.StatusTeapot)
+	if rec.Code != http.StatusOK {
+		t.Errorf("WriteHeader after timeout reached the underlying writer: code = %d", rec.Code)
+	}
+	if rw.wroteHeader.Load() {
+		t.Error("WriteHeader after timeout must not mark the header as written")
+	}
+
+	n, err := rw.Write([]byte("late"))
+	if n != 0 || err != http.ErrHandlerTimeout {
+		t.Errorf("Write after timeout = (%d, %v), want (0, http.ErrHandlerTimeout)", n, err)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("Write after timeout reached the underlying writer: body = %q", rec.Body.String())
+	}
+
+	rw.Flush()
+	if rec.Flushed {
+		t.Error("Flush after timeout must not flush the underlying writer")
+	}
+}
+
+// TestMutexResponseWriterWriteRecheckUnderLock verifies the race window where
+// a handler Write passes the initial timeout check but the timeout response is
+// written while the handler is waiting for the mutex: the write must be
+// rejected by the re-check under the lock instead of corrupting the response.
+func TestMutexResponseWriterWriteRecheckUnderLock(t *testing.T) {
+	rec := httptest.NewRecorder()
+	var mu sync.Mutex
+	rw := &mutexResponseWriter{ResponseWriter: rec, mu: &mu}
+
+	// Hold the lock as the timeout path does while writing its response.
+	mu.Lock()
+	writeErr := make(chan error)
+	go func() {
+		_, err := rw.Write([]byte("late"))
+		writeErr <- err
+	}()
+
+	// Let the handler write pass the initial check and block on the mutex,
+	// then mark the timeout before releasing the lock.
+	time.Sleep(50 * time.Millisecond)
+	rw.timedOut.Store(true)
+	mu.Unlock()
+
+	if err := <-writeErr; err != http.ErrHandlerTimeout {
+		t.Errorf("late Write = %v, want http.ErrHandlerTimeout", err)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("late Write reached the underlying writer: body = %q", rec.Body.String())
+	}
+}

--- a/pkg/middleware/trace_validation_test.go
+++ b/pkg/middleware/trace_validation_test.go
@@ -1,0 +1,113 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Suhaibinator/SRouter/pkg/scontext"
+)
+
+// TestIsValidTraceID exercises the character-class and length validation for
+// inbound X-Trace-ID values.
+func TestIsValidTraceID(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want bool
+	}{
+		{"empty", "", false},
+		{"digits only", "0123456789", true},
+		{"lowercase letters", "abcxyz", true},
+		{"uppercase letters", "ABCXYZ", true},
+		{"dash and underscore", "trace-id_1", true},
+		{"mixed valid", "REQ-123_abcXYZ", true},
+		{"max length (64)", strings.Repeat("a", 64), true},
+		{"too long (65)", strings.Repeat("a", 65), false},
+		{"disallowed punctuation", "abc!123", false},
+		{"embedded newline", "abc\n123", false},
+		{"embedded space", "abc 123", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isValidTraceID(tc.id); got != tc.want {
+				t.Errorf("isValidTraceID(%q) = %v, want %v", tc.id, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestTraceMiddlewarePropagatesValidInboundTraceID verifies that a valid
+// client-supplied X-Trace-ID is propagated unchanged to both the request
+// context and the response header.
+func TestTraceMiddlewarePropagatesValidInboundTraceID(t *testing.T) {
+	generator := NewIDGenerator(4)
+	defer generator.Stop()
+
+	const inbound = "REQ-123_abcXYZ"
+	var handlerTraceID string
+	handler := CreateTraceMiddleware[string, any](generator)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlerTraceID = scontext.GetTraceIDFromRequest[string, any](r)
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Trace-ID", inbound)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if handlerTraceID != inbound {
+		t.Errorf("handler saw trace ID %q, want propagated inbound ID %q", handlerTraceID, inbound)
+	}
+	if got := rec.Header().Get("X-Trace-ID"); got != inbound {
+		t.Errorf("response X-Trace-ID = %q, want propagated inbound ID %q", got, inbound)
+	}
+}
+
+// TestTraceMiddlewareReplacesInvalidInboundTraceID verifies that invalid
+// client-supplied trace IDs (oversized or containing unsafe characters) are
+// not propagated: the middleware substitutes a freshly generated, valid ID.
+func TestTraceMiddlewareReplacesInvalidInboundTraceID(t *testing.T) {
+	generator := NewIDGenerator(4)
+	defer generator.Stop()
+
+	tests := []struct {
+		name    string
+		inbound string
+	}{
+		{"oversized", strings.Repeat("a", 65)},
+		{"log injection attempt", "abc\nINJECTED"},
+		{"disallowed characters", "abc!123"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var handlerTraceID string
+			handler := CreateTraceMiddleware[string, any](generator)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				handlerTraceID = scontext.GetTraceIDFromRequest[string, any](r)
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req := httptest.NewRequest("GET", "/", nil)
+			req.Header.Set("X-Trace-ID", tc.inbound)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			got := rec.Header().Get("X-Trace-ID")
+			if got == tc.inbound {
+				t.Fatalf("invalid inbound trace ID %q was propagated; it should have been replaced", tc.inbound)
+			}
+			if got == "" {
+				t.Fatal("expected a generated trace ID in the response header, got empty")
+			}
+			if !isValidTraceID(got) {
+				t.Errorf("generated replacement trace ID %q is not itself valid", got)
+			}
+			if handlerTraceID != got {
+				t.Errorf("handler saw trace ID %q but response header has %q; they must match", handlerTraceID, got)
+			}
+		})
+	}
+}

--- a/pkg/router/patch_coverage_test.go
+++ b/pkg/router/patch_coverage_test.go
@@ -1,0 +1,205 @@
+package router
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Suhaibinator/SRouter/pkg/common"
+	"github.com/Suhaibinator/SRouter/pkg/metrics"
+	"github.com/Suhaibinator/SRouter/pkg/router/internal/mocks"
+)
+
+// fakeMetricsMiddlewareFactory implements metrics.MetricsMiddleware[string, string]
+// so tests can verify that a user-supplied MiddlewareFactory takes precedence
+// over building middleware from the Collector.
+type fakeMetricsMiddlewareFactory struct {
+	mu           sync.Mutex
+	handlerNames []string
+	requests     int
+}
+
+func (f *fakeMetricsMiddlewareFactory) Handler(name string, handler http.Handler) http.Handler {
+	f.mu.Lock()
+	f.handlerNames = append(f.handlerNames, name)
+	f.mu.Unlock()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		f.requests++
+		f.mu.Unlock()
+		w.Header().Set("X-Metrics-Factory", "invoked")
+		handler.ServeHTTP(w, r)
+	})
+}
+
+func (f *fakeMetricsMiddlewareFactory) Configure(config metrics.MetricsMiddlewareConfig) metrics.MetricsMiddleware[string, string] {
+	return f
+}
+
+func (f *fakeMetricsMiddlewareFactory) WithFilter(filter metrics.MetricsFilter) metrics.MetricsMiddleware[string, string] {
+	return f
+}
+
+func (f *fakeMetricsMiddlewareFactory) WithSampler(sampler metrics.MetricsSampler) metrics.MetricsMiddleware[string, string] {
+	return f
+}
+
+// TestMetricsConfigMiddlewareFactory verifies that when MetricsConfig supplies
+// a MiddlewareFactory of the router's generic type, the router wraps handlers
+// with it (passing the configured ServiceName) and requests flow through it.
+func TestMetricsConfigMiddlewareFactory(t *testing.T) {
+	factory := &fakeMetricsMiddlewareFactory{}
+
+	r := NewRouter(RouterConfig{
+		ServiceName: "test-service",
+		MetricsConfig: &MetricsConfig{
+			MiddlewareFactory: factory,
+		},
+	}, mocks.MockAuthFunction, mocks.MockUserIDFromUser)
+
+	r.RegisterRoute(RouteConfigBase{
+		Path:    "/factory",
+		Methods: []HttpMethod{MethodGet},
+		Handler: func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		},
+	})
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest("GET", "/factory", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if rec.Header().Get("X-Metrics-Factory") != "invoked" {
+		t.Error("request did not pass through the factory-provided metrics middleware")
+	}
+
+	factory.mu.Lock()
+	defer factory.mu.Unlock()
+	if factory.requests != 1 {
+		t.Errorf("factory middleware handled %d requests, want 1", factory.requests)
+	}
+	if len(factory.handlerNames) == 0 {
+		t.Fatal("factory Handler was never called when wrapping routes")
+	}
+	for _, name := range factory.handlerNames {
+		if name != "test-service" {
+			t.Errorf("factory Handler called with name %q, want configured ServiceName %q", name, "test-service")
+		}
+	}
+}
+
+// TestGetEffectiveRateLimitConvertsUserIDFunctions verifies that converting a
+// RateLimitConfig[any, any] override to the router's concrete types adapts
+// UserIDFromUser and UserIDToString so user-based rate limiting keeps working.
+func TestGetEffectiveRateLimitConvertsUserIDFunctions(t *testing.T) {
+	r := NewRouter(RouterConfig{}, mocks.MockAuthFunction, mocks.MockUserIDFromUser)
+
+	src := &common.RateLimitConfig[any, any]{
+		BucketName: "user-bucket",
+		Limit:      7,
+		Window:     time.Minute,
+		Strategy:   common.StrategyUser,
+		UserIDFromUser: func(user any) any {
+			return "id-" + user.(string)
+		},
+		UserIDToString: func(userID any) string {
+			return "key:" + userID.(string)
+		},
+	}
+
+	got := r.getEffectiveRateLimit(src, nil)
+	if got == nil {
+		t.Fatal("expected a converted rate limit config, got nil")
+	}
+	if got.BucketName != "user-bucket" || got.Limit != 7 || got.Window != time.Minute || got.Strategy != common.StrategyUser {
+		t.Errorf("converted config lost fields: %+v", got)
+	}
+	if got.UserIDFromUser == nil {
+		t.Fatal("UserIDFromUser was not adapted across the type conversion")
+	}
+	if id := got.UserIDFromUser("alice"); id != "id-alice" {
+		t.Errorf("UserIDFromUser(\"alice\") = %q, want %q", id, "id-alice")
+	}
+	if got.UserIDToString == nil {
+		t.Fatal("UserIDToString was not adapted across the type conversion")
+	}
+	if key := got.UserIDToString("bob"); key != "key:bob" {
+		t.Errorf("UserIDToString(\"bob\") = %q, want %q", key, "key:bob")
+	}
+
+	// A UserIDFromUser returning a value of the wrong type must degrade to the
+	// zero user ID instead of panicking. Passed as the sub-router override to
+	// exercise that precedence level too.
+	wrongType := &common.RateLimitConfig[any, any]{
+		Limit:  1,
+		Window: time.Second,
+		UserIDFromUser: func(user any) any {
+			return 42 // not a string
+		},
+	}
+	converted := r.getEffectiveRateLimit(nil, wrongType)
+	if converted == nil || converted.UserIDFromUser == nil {
+		t.Fatal("expected converted sub-router config with adapted UserIDFromUser")
+	}
+	if id := converted.UserIDFromUser("alice"); id != "" {
+		t.Errorf("UserIDFromUser with mismatched return type = %q, want zero value", id)
+	}
+}
+
+// TestExtractIPFromXForwardedForBlankEntries verifies that an X-Forwarded-For
+// header containing only blank entries (commas and whitespace) yields no IP,
+// so the caller falls back to RemoteAddr instead of using an empty key.
+func TestExtractIPFromXForwardedForBlankEntries(t *testing.T) {
+	for _, xff := range []string{" ", ",", " , ", ",,  ,"} {
+		req := httptest.NewRequest("GET", "/", nil)
+		req.Header.Set("X-Forwarded-For", xff)
+		if ip := extractIPFromXForwardedFor(req); ip != "" {
+			t.Errorf("X-Forwarded-For %q: got %q, want empty string", xff, ip)
+		}
+	}
+
+	// End to end: with a blank XFF the extracted client IP must fall back to
+	// RemoteAddr even when proxy headers are trusted.
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "203.0.113.9:1234"
+	req.Header.Set("X-Forwarded-For", " , ")
+	ip := extractClientIP(req, &IPConfig{Source: IPSourceXForwardedFor, TrustProxy: true})
+	if ip != "203.0.113.9" {
+		t.Errorf("extractClientIP with blank XFF = %q, want RemoteAddr fallback %q", ip, "203.0.113.9")
+	}
+}
+
+// TestRouterMutexResponseWriterWriteRecheckUnderLock verifies the router's
+// timeout response writer rejects a handler write that passed the initial
+// timeout check but lost the race to the timeout response: the re-check under
+// the lock must fail the write instead of corrupting the response.
+func TestRouterMutexResponseWriterWriteRecheckUnderLock(t *testing.T) {
+	rec := httptest.NewRecorder()
+	var mu sync.Mutex
+	rw := &mutexResponseWriter{ResponseWriter: rec, mu: &mu}
+
+	// Hold the lock as the timeout path does while writing its response.
+	mu.Lock()
+	writeErr := make(chan error)
+	go func() {
+		_, err := rw.Write([]byte("late"))
+		writeErr <- err
+	}()
+
+	// Let the handler write pass the initial check and block on the mutex,
+	// then mark the timeout before releasing the lock.
+	time.Sleep(50 * time.Millisecond)
+	rw.timedOut.Store(true)
+	mu.Unlock()
+
+	if err := <-writeErr; err != http.ErrHandlerTimeout {
+		t.Errorf("late Write = %v, want http.ErrHandlerTimeout", err)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("late Write reached the underlying writer: body = %q", rec.Body.String())
+	}
+}

--- a/pkg/scontext/missing_context_test.go
+++ b/pkg/scontext/missing_context_test.go
@@ -1,0 +1,72 @@
+package scontext
+
+import (
+	"context"
+	"testing"
+)
+
+// TestGettersWithoutSRouterContext verifies that every getter degrades
+// gracefully when called on a context that has no SRouterContext — e.g. a
+// helper invoked outside the router's middleware chain. Each getter must
+// return its zero value and report not-found instead of panicking or
+// returning stale data.
+func TestGettersWithoutSRouterContext(t *testing.T) {
+	ctx := context.Background()
+
+	if id, ok := GetUserID[string, any](ctx); ok || id != "" {
+		t.Errorf("GetUserID = (%q, %v), want (\"\", false)", id, ok)
+	}
+	if user, ok := GetUser[string, any](ctx); ok || user != nil {
+		t.Errorf("GetUser = (%v, %v), want (nil, false)", user, ok)
+	}
+	if value, exists := GetFlag[string, any](ctx, "feature"); exists || value {
+		t.Errorf("GetFlag = (%v, %v), want (false, false)", value, exists)
+	}
+	if ip, ok := GetClientIP[string, any](ctx); ok || ip != "" {
+		t.Errorf("GetClientIP = (%q, %v), want (\"\", false)", ip, ok)
+	}
+	if ua, ok := GetUserAgent[string, any](ctx); ok || ua != "" {
+		t.Errorf("GetUserAgent = (%q, %v), want (\"\", false)", ua, ok)
+	}
+	if tx, ok := GetTransaction[string, any](ctx); ok || tx != nil {
+		t.Errorf("GetTransaction = (%v, %v), want (nil, false)", tx, ok)
+	}
+	if traceID := GetTraceIDFromContext[string, any](ctx); traceID != "" {
+		t.Errorf("GetTraceIDFromContext = %q, want \"\"", traceID)
+	}
+	if tmpl, ok := GetRouteTemplateFromContext[string, any](ctx); ok || tmpl != "" {
+		t.Errorf("GetRouteTemplateFromContext = (%q, %v), want (\"\", false)", tmpl, ok)
+	}
+	if params, ok := GetPathParamsFromContext[string, any](ctx); ok || params != nil {
+		t.Errorf("GetPathParamsFromContext = (%v, %v), want (nil, false)", params, ok)
+	}
+	if origin, creds, ok := GetCORSInfo[string, any](ctx); ok || origin != "" || creds {
+		t.Errorf("GetCORSInfo = (%q, %v, %v), want (\"\", false, false)", origin, creds, ok)
+	}
+	if hdrs, ok := GetCORSRequestedHeaders[string, any](ctx); ok || hdrs != "" {
+		t.Errorf("GetCORSRequestedHeaders = (%q, %v), want (\"\", false)", hdrs, ok)
+	}
+	if err, ok := GetHandlerError[string, any](ctx); ok || err != nil {
+		t.Errorf("GetHandlerError = (%v, %v), want (nil, false)", err, ok)
+	}
+}
+
+// TestGettersWithSRouterContextButUnsetValues verifies that getters report
+// not-found when an SRouterContext exists but the specific value was never set,
+// so callers can distinguish "never set" from a set zero value.
+func TestGettersWithSRouterContextButUnsetValues(t *testing.T) {
+	ctx := WithSRouterContext(context.Background(), NewSRouterContext[string, any]())
+
+	if id, ok := GetUserID[string, any](ctx); ok || id != "" {
+		t.Errorf("GetUserID = (%q, %v), want (\"\", false)", id, ok)
+	}
+	if value, exists := GetFlag[string, any](ctx, "feature"); exists || value {
+		t.Errorf("GetFlag = (%v, %v), want (false, false)", value, exists)
+	}
+	if traceID := GetTraceIDFromContext[string, any](ctx); traceID != "" {
+		t.Errorf("GetTraceIDFromContext = %q, want \"\"", traceID)
+	}
+	if origin, creds, ok := GetCORSInfo[string, any](ctx); ok || origin != "" || creds {
+		t.Errorf("GetCORSInfo = (%q, %v, %v), want (\"\", false, false)", origin, creds, ok)
+	}
+}


### PR DESCRIPTION
## Summary
This PR adds extensive test coverage for critical functionality across the router, middleware, and context packages. The new tests validate edge cases, race conditions, and integration scenarios that were previously untested.

## Key Changes

### Router Package (`pkg/router/patch_coverage_test.go`)
- **Metrics middleware factory integration**: Verifies that user-supplied `MetricsMiddlewareFactory` takes precedence and wraps handlers with the configured service name
- **Rate limit type conversion**: Tests that `getEffectiveRateLimit()` correctly adapts generic `RateLimitConfig[any, any]` to concrete router types, including proper handling of `UserIDFromUser` and `UserIDToString` function conversions with type safety
- **Type mismatch degradation**: Validates that mismatched return types in user ID functions degrade gracefully to zero values instead of panicking
- **X-Forwarded-For parsing**: Ensures blank/whitespace-only XFF headers correctly fall back to `RemoteAddr` instead of using empty keys
- **Timeout response writer race condition**: Tests the critical re-check-under-lock pattern in `mutexResponseWriter.Write()` to prevent response corruption when a write passes the initial timeout check but loses the race to the timeout response

### Metrics Package (`pkg/metrics/handler_method_test.go`)
- **Default tags application**: Verifies that `DefaultTags` from middleware config are applied to all metrics, empty-valued tags are skipped, and route/status-specific tags are still added
- **Metric caching and reuse**: Confirms that per-route metric instances are built once and reused across requests, accumulating values correctly rather than rebuilding fresh metrics

### Middleware Package
- **Trace validation** (`pkg/middleware/trace_validation_test.go`):
  - Character class and length validation for X-Trace-ID (alphanumeric, dash, underscore; max 64 chars)
  - Valid inbound trace IDs are propagated unchanged to context and response headers
  - Invalid trace IDs (oversized, log injection attempts, disallowed characters) are replaced with freshly generated valid IDs
  
- **Timeout writer** (`pkg/middleware/timeout_writer_test.go`):
  - Partial responses started before timeout are not overwritten with 408 responses
  - All writes (WriteHeader, Write, Flush) are rejected after timeout with appropriate errors
  - Race condition handling: writes that pass initial check but timeout while waiting for mutex are rejected by re-check under lock
  
- **Rate limiting** (`pkg/middleware/ratelimit_slidingwindow_test.go`):
  - Sliding window rollover weights previous window proportionally to overlap, smoothing bursts at boundaries
  - Non-positive limits deny all requests immediately
  - Zero/negative windows default to one-second window instead of degenerating

### Context Package (`pkg/scontext/missing_context_test.go`)
- **Missing SRouterContext**: All getters degrade gracefully when called on contexts without SRouterContext, returning zero values and reporting not-found
- **Unset values**: Getters correctly distinguish between "never set" and "set to zero value" when SRouterContext exists but specific values were never populated

## Notable Implementation Details
- Tests use synchronization primitives (channels, mutexes, time.Sleep) to reliably trigger race conditions and validate concurrent behavior
- Mock implementations (fakeMetricsMiddlewareFactory, mock registries) enable isolated testing of integration points
- Type conversion tests validate the generic-to-concrete adaptation layer that bridges user-supplied generic configs to router-specific types
- Edge case coverage includes boundary conditions (window rollover, max trace ID length, blank header values) and error paths (type mismatches, invalid inputs)

https://claude.ai/code/session_01K1jbTLDqeuC16p7eJTWJaN