### PR TITLE
Simplify rate limiting and timeout error handling

### DIFF
--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -114,16 +114,10 @@ func timeout(timeout time.Duration) Middleware {
 				// Handler finished normally
 				return
 			case <-ctx.Done():
-				// Timeout occurred. If the handler already started writing,
+				// Timeout occurred. If the handler already started writing
+				// (or claims the response concurrently with the timeout),
 				// don't write a second response on top of it.
-				if wrappedW.wroteHeader.Load() {
-					return
-				}
-
-				// Reject any further handler writes so they can't race with
-				// the timeout response on the underlying writer.
-				wrappedW.timedOut.Store(true)
-				if !wrappedW.wroteHeader.CompareAndSwap(false, true) {
+				if wrappedW.wroteHeader.Load() || !wrappedW.markTimedOut() {
 					return
 				}
 
@@ -145,6 +139,16 @@ type mutexResponseWriter struct {
 	mu          *sync.Mutex
 	wroteHeader atomic.Bool // Tracks if WriteHeader or Write has been called
 	timedOut    atomic.Bool // When true, reject all writes to the underlying writer
+}
+
+// markTimedOut transitions the writer into the timed-out state, rejecting all
+// further handler writes, and attempts to claim the response for the timeout
+// handler. It returns false if a handler write claimed the response first (in
+// the window between the caller's last check and this transition), in which
+// case the timeout response must be suppressed.
+func (rw *mutexResponseWriter) markTimedOut() bool {
+	rw.timedOut.Store(true)
+	return rw.wroteHeader.CompareAndSwap(false, true)
 }
 
 // WriteHeader acquires the mutex and calls the underlying ResponseWriter.WriteHeader.

--- a/pkg/middleware/ratelimit.go
+++ b/pkg/middleware/ratelimit.go
@@ -76,19 +76,14 @@ func (l *slidingWindowLimiter) allow(limit int, window time.Duration, now time.T
 
 	if estimated >= limit {
 		// Denied: report how long until the current window rolls over.
-		reset := window - elapsed
-		if reset < 0 {
-			reset = 0
-		}
-		return false, 0, reset
+		// The rollover above keeps elapsed within [0, window), so this is
+		// always positive.
+		return false, 0, window - elapsed
 	}
 
 	l.currCount++
-	remaining := limit - estimated - 1
-	if remaining < 0 {
-		remaining = 0
-	}
-	return true, remaining, 0
+	// estimated < limit here, so the remaining count is never negative.
+	return true, limit - estimated - 1, 0
 }
 
 // getLimiter gets or creates a window counter for the given key, limit, and window.
@@ -162,33 +157,30 @@ func convertUserIDToString[T comparable](userID T) string {
 // If config.UserIDToString is nil, a default conversion (convertUserIDToString) is used,
 // so StrategyUser works out of the box for common ID types.
 // Returns an empty string if no user information is found.
-func extractUserKey[T comparable, U any](r *http.Request, config *common.RateLimitConfig[T, U]) (string, error) { // Use common.RateLimitConfig
+func extractUserKey[T comparable, U any](r *http.Request, config *common.RateLimitConfig[T, U]) string { // Use common.RateLimitConfig
 	userIDToString := config.UserIDToString
 	if userIDToString == nil {
 		userIDToString = convertUserIDToString[T]
 	}
 
-	// Try getting the full user object first
+	// Try getting the full user object first. Extracting an ID from it
+	// requires the UserIDFromUser function; without it, fall through to the
+	// user ID from the context.
 	user, userOk := scontext.GetUserFromRequest[T, U](r) // Use scontext
-	if userOk && user != nil {
-		if config.UserIDFromUser == nil {
-			// Cannot extract ID from user object without UserIDFromUser function
-			// Try falling back to UserID directly
-		} else {
-			userID := config.UserIDFromUser(*user)
-			return userIDToString(userID), nil
-		}
+	if userOk && user != nil && config.UserIDFromUser != nil {
+		userID := config.UserIDFromUser(*user)
+		return userIDToString(userID)
 	}
 
 	// Fallback: Try getting the user ID directly from context
 	userID, idOk := scontext.GetUserIDFromRequest[T, U](r) // Use scontext
 	if idOk {
 		// Use the conversion function
-		return userIDToString(userID), nil
+		return userIDToString(userID)
 	}
 
 	// No user information found in context
-	return "", nil // Return empty key, let the caller decide how to handle (e.g., fallback to IP)
+	return "" // Return empty key, let the caller decide how to handle (e.g., fallback to IP)
 }
 
 // RateLimit creates a middleware that enforces rate limits based on the provided configuration.
@@ -240,16 +232,7 @@ func RateLimit[T comparable, U any](config *common.RateLimitConfig[T, U], limite
 
 			case common.StrategyUser: // Use common.StrategyUser
 				strategyUsed = "User"
-				key, err = extractUserKey(r, config)
-				if err != nil {
-					logger.Error("Failed to extract user key for rate limiting",
-						zap.Error(err),
-						zap.String("method", r.Method),
-						zap.String("path", r.URL.Path),
-					)
-					http.Error(w, "Internal Server Error", http.StatusInternalServerError)
-					return
-				}
+				key = extractUserKey(r, config)
 				// If no user key found, fall back to IP strategy as a safety measure
 				if key == "" {
 					strategyUsed = "User (fallback to IP)"

--- a/pkg/middleware/ratelimit_codecov_test.go
+++ b/pkg/middleware/ratelimit_codecov_test.go
@@ -54,8 +54,8 @@ func TestUberRateLimiter_AllowedCondition(t *testing.T) {
 }
 
 // TestExtractUserKey_NilUserIDToString verifies that a nil UserIDToString
-// falls back to the default conversion instead of returning an error, so
-// StrategyUser works when configured via [any, any] overrides.
+// falls back to the default conversion, so StrategyUser works when configured
+// via [any, any] overrides.
 func TestExtractUserKey_NilUserIDToString_Codecov(t *testing.T) {
 	// Create a request with a user ID in the context
 	req := httptest.NewRequest("GET", "/", nil)
@@ -70,10 +70,9 @@ func TestExtractUserKey_NilUserIDToString_Codecov(t *testing.T) {
 	}
 
 	// Call extractUserKey
-	key, err := extractUserKey(req, config)
+	key := extractUserKey(req, config)
 
-	// Verify the default conversion is used and no error is returned
-	assert.NoError(t, err, "extractUserKey should not error when UserIDToString is nil")
+	// Verify the default conversion is used
 	assert.Equal(t, "user-42", key, "Key should come from the default user ID conversion")
 }
 

--- a/pkg/middleware/ratelimit_coverage_test.go
+++ b/pkg/middleware/ratelimit_coverage_test.go
@@ -413,10 +413,9 @@ func TestExtractUserKey_NilUserIDToString(t *testing.T) {
 	}
 
 	// Call extractUserKey
-	key, err := extractUserKey(req, config)
+	key := extractUserKey(req, config)
 
-	// Verify the default conversion is used and no error is returned
-	assert.NoError(t, err, "extractUserKey should not error when UserIDToString is nil")
+	// Verify the default conversion is used
 	assert.Equal(t, "test-user", key, "Key should come from the default user ID conversion")
 }
 

--- a/pkg/middleware/ratelimit_generic_additional_test.go
+++ b/pkg/middleware/ratelimit_generic_additional_test.go
@@ -45,10 +45,7 @@ func TestExtractUser(t *testing.T) {
 		}
 
 		// Extract the user key
-		userKey, err := extractUserKey(req, config) // Use extractUserKey
-		if err != nil {
-			t.Fatalf("extractUserKey failed: %v", err)
-		}
+		userKey := extractUserKey(req, config)
 		if userKey != "testUser" {
 			t.Errorf("Expected user key 'testUser', got '%s'", userKey)
 		}
@@ -71,10 +68,7 @@ func TestExtractUser(t *testing.T) {
 		}
 
 		// Extract the user key - the default conversion is used when UserIDToString is nil
-		userKey, err := extractUserKey(req, config) // Use extractUserKey
-		if err != nil {
-			t.Fatalf("extractUserKey failed: %v", err)
-		}
+		userKey := extractUserKey(req, config)
 		if userKey != "testUser-modified" {
 			t.Errorf("Expected user key 'testUser-modified', got '%s'", userKey)
 		}
@@ -99,10 +93,7 @@ func TestExtractUser(t *testing.T) {
 		// Extract the user key
 		// Add UserIDToString for int
 		config.UserIDToString = func(id int) string { return strconv.Itoa(id) }
-		userKey, err := extractUserKey(req, config) // Use extractUserKey
-		if err != nil {
-			t.Fatalf("extractUserKey failed: %v", err)
-		}
+		userKey := extractUserKey(req, config)
 		if userKey != "42" {
 			t.Errorf("Expected user key '42', got '%s'", userKey)
 		}
@@ -130,10 +121,7 @@ func TestExtractUser(t *testing.T) {
 		// Extract the user key
 		// Add UserIDToString for CustomID
 		config.UserIDToString = func(id CustomID) string { return id.String() } // Use String() method
-		userKey, err := extractUserKey(req, config)                             // Use extractUserKey
-		if err != nil {
-			t.Fatalf("extractUserKey failed: %v", err)
-		}
+		userKey := extractUserKey(req, config)
 		if userKey != "custom-id" { // Expect the result of String()
 			t.Errorf("Expected user key 'custom-id', got '%s'", userKey)
 		}
@@ -155,10 +143,7 @@ func TestExtractUser(t *testing.T) {
 		}
 
 		// Extract the user key
-		extractedKey, err := extractUserKey(req, config) // Use extractUserKey
-		if err != nil {
-			t.Fatalf("extractUserKey failed: %v", err)
-		}
+		extractedKey := extractUserKey(req, config)
 		if extractedKey != "user123-suffix" {
 			t.Errorf("Expected user key 'user123-suffix', got '%s'", extractedKey)
 		}
@@ -178,10 +163,7 @@ func TestExtractUser(t *testing.T) {
 		}
 
 		// Extract the user key - the default string conversion applies
-		extractedKey, err := extractUserKey(req, config) // Use extractUserKey
-		if err != nil {
-			t.Fatalf("extractUserKey failed: %v", err)
-		}
+		extractedKey := extractUserKey(req, config)
 		if extractedKey != "user123" {
 			t.Errorf("Expected user key 'user123', got '%s'", extractedKey)
 		}
@@ -201,10 +183,7 @@ func TestExtractUser(t *testing.T) {
 		}
 
 		// Extract the user key
-		extractedKey, err := extractUserKey(req, config) // Use extractUserKey
-		if err != nil {
-			t.Fatalf("extractUserKey failed: %v", err)
-		}
+		extractedKey := extractUserKey(req, config)
 		if extractedKey != "42" {
 			t.Errorf("Expected user key '42', got '%s'", extractedKey)
 		}
@@ -224,10 +203,7 @@ func TestExtractUser(t *testing.T) {
 		}
 
 		// Extract the user key
-		extractedKey, err := extractUserKey(req, config) // Use extractUserKey
-		if err != nil {
-			t.Fatalf("extractUserKey failed: %v", err)
-		}
+		extractedKey := extractUserKey(req, config)
 		if extractedKey != "true" {
 			t.Errorf("Expected user key 'true', got '%s'", extractedKey)
 		}
@@ -244,10 +220,7 @@ func TestExtractUser(t *testing.T) {
 		}
 
 		// Extract the user key
-		extractedKey, err := extractUserKey(req, config) // Use extractUserKey
-		if err != nil {
-			t.Fatalf("extractUserKey failed: %v", err)
-		}
+		extractedKey := extractUserKey(req, config)
 		if extractedKey != "" {
 			t.Errorf("Expected empty user key, got '%s'", extractedKey)
 		}

--- a/pkg/middleware/ratelimit_test.go
+++ b/pkg/middleware/ratelimit_test.go
@@ -173,7 +173,13 @@ func TestConvertUserIDToString(t *testing.T) {
 		t.Errorf("Expected string to be true, got %s", str)
 	}
 
-	// Test with a custom type that implements String()
+	// Test with a custom type that implements fmt.Stringer
+	str = convertUserIDToString(CustomID{id: "custom-id"})
+	if str != "custom-id" {
+		t.Errorf("Expected string to be custom-id, got %s", str)
+	}
+
+	// Test with a custom type without a String method (fmt.Sprint fallback)
 	type CustomType struct{}
 	str = convertUserIDToString(CustomType{})
 	if str != "{}" {
@@ -853,5 +859,54 @@ func TestUberRateLimiter_WindowSemanticsAndNonBlocking(t *testing.T) {
 	// the next leaky-bucket slot before denying).
 	if elapsed := time.Since(start); elapsed > 100*time.Millisecond {
 		t.Fatalf("Allow calls blocked for %v; rate limit checks must be non-blocking", elapsed)
+	}
+}
+
+// TestRateLimitDefaultStrategyUsesContextIP verifies that an unknown strategy
+// falls back to IP-based limiting using the client IP from the context when
+// it is available (rather than RemoteAddr).
+func TestRateLimitDefaultStrategyUsesContextIP(t *testing.T) {
+	limiter := &captureLimiter{}
+	config := &common.RateLimitConfig[string, any]{
+		BucketName: "test-bucket",
+		Limit:      1,
+		Window:     time.Second,
+		Strategy:   common.RateLimitStrategy(99), // Unknown strategy triggers the default case
+	}
+
+	middleware := RateLimit(config, limiter, zap.NewNop())
+	handler := middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+	req.RemoteAddr = "10.0.0.1:1234" // ensure remote addr differs from context IP
+	ctx := scontext.WithClientIP[string, any](req.Context(), "203.0.113.9")
+
+	handler.ServeHTTP(httptest.NewRecorder(), req.WithContext(ctx))
+
+	expectedKey := "test-bucket:203.0.113.9"
+	if limiter.lastKey != expectedKey {
+		t.Fatalf("expected limiter key %s, got %s", expectedKey, limiter.lastKey)
+	}
+}
+
+// TestExtractUserKeyUserObjectWithoutUserIDFromUser verifies that when a user
+// object is in the context but no UserIDFromUser function is configured, the
+// key falls back to the user ID from the context.
+func TestExtractUserKeyUserObjectWithoutUserIDFromUser(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+	user := "userObject"
+	ctx := scontext.WithUser[string](req.Context(), &user)
+	ctx = scontext.WithUserID[string, string](ctx, "id-from-context")
+	req = req.WithContext(ctx)
+
+	config := &common.RateLimitConfig[string, string]{
+		Strategy: common.StrategyUser,
+		// No UserIDFromUser: the user object alone cannot produce a key.
+	}
+
+	if key := extractUserKey(req, config); key != "id-from-context" {
+		t.Fatalf("expected fallback to user ID from context, got %q", key)
 	}
 }

--- a/pkg/middleware/timeout_writer_test.go
+++ b/pkg/middleware/timeout_writer_test.go
@@ -104,3 +104,39 @@ func TestMutexResponseWriterWriteRecheckUnderLock(t *testing.T) {
 		t.Errorf("late Write reached the underlying writer: body = %q", rec.Body.String())
 	}
 }
+
+// TestMutexResponseWriterMarkTimedOut verifies the timed-out transition the
+// timeout middleware performs when the deadline fires: it must reject further
+// handler writes, and it may only claim the response if no handler write got
+// there first.
+func TestMutexResponseWriterMarkTimedOut(t *testing.T) {
+	t.Run("claims an unwritten response", func(t *testing.T) {
+		var mu sync.Mutex
+		rw := &mutexResponseWriter{ResponseWriter: httptest.NewRecorder(), mu: &mu}
+
+		if !rw.markTimedOut() {
+			t.Error("markTimedOut must claim the response when nothing was written")
+		}
+		if !rw.timedOut.Load() {
+			t.Error("markTimedOut must put the writer into the timed-out state")
+		}
+		if n, err := rw.Write([]byte("late")); n != 0 || err != http.ErrHandlerTimeout {
+			t.Errorf("Write after markTimedOut = (%d, %v), want (0, http.ErrHandlerTimeout)", n, err)
+		}
+	})
+
+	t.Run("does not claim a response a handler write got to first", func(t *testing.T) {
+		var mu sync.Mutex
+		rw := &mutexResponseWriter{ResponseWriter: httptest.NewRecorder(), mu: &mu}
+		// A handler write claimed the response between the middleware's last
+		// wroteHeader check and the timed-out transition.
+		rw.wroteHeader.Store(true)
+
+		if rw.markTimedOut() {
+			t.Error("markTimedOut must not claim a response the handler already started")
+		}
+		if !rw.timedOut.Load() {
+			t.Error("markTimedOut must put the writer into the timed-out state even when it cannot claim the response")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
This PR refactors error handling in the rate limiting and timeout middleware to eliminate unnecessary error returns and simplifies the logic for claiming responses during timeouts.

## Key Changes

### Rate Limiting (`pkg/middleware/ratelimit.go`)
- **Removed error return from `extractUserKey`**: Changed signature from `(string, error)` to `string` since the function never returns errors—it gracefully falls back to empty string when user information is unavailable
- **Simplified `slidingWindowLimiter.allow`**: Removed defensive negative checks for `reset` and `remaining` values since the logic guarantees they are always non-negative; added clarifying comments
- **Removed error handling in `RateLimit` middleware**: Eliminated the error check and HTTP 500 response for `extractUserKey` since it no longer returns errors

### Timeout Middleware (`pkg/middleware/middleware.go`)
- **Extracted `markTimedOut` method**: Created a new `mutexResponseWriter.markTimedOut()` method that atomically transitions the writer to timed-out state and attempts to claim the response
- **Simplified timeout logic**: Replaced manual atomic operations with the new method, making the race condition handling more explicit and easier to understand
- **Improved concurrency safety**: The new method clearly documents the window where a handler write can race with the timeout transition

### Tests
- **Updated rate limiting tests**: Removed error handling from all `extractUserKey` calls across test files
- **Added new test cases**:
  - `TestRateLimitDefaultStrategyUsesContextIP`: Verifies unknown strategies fall back to IP-based limiting using context IP
  - `TestExtractUserKeyUserObjectWithoutUserIDFromUser`: Verifies fallback to user ID from context when `UserIDFromUser` is not configured
  - `TestMutexResponseWriterMarkTimedOut`: Comprehensive tests for the new `markTimedOut` method covering both claimed and unclaimed response scenarios
- **Improved test comments**: Enhanced documentation in `TestConvertUserIDToString` to clarify the distinction between `fmt.Stringer` and fallback behavior

## Implementation Details
- The `extractUserKey` simplification maintains the same fallback behavior (user object → user ID → empty string) but removes the error path that was never used
- The `markTimedOut` method uses `CompareAndSwap` to ensure the timeout handler only writes a response if the handler hasn't already started writing
- All changes maintain backward compatibility and existing behavior while improving code clarity

https://claude.ai/code/session_013sdsD6aw5dnaZhZXexg882